### PR TITLE
Add vars and template for logging configuration

### DIFF
--- a/roles/amq_broker/README.md
+++ b/roles/amq_broker/README.md
@@ -103,6 +103,23 @@ Role Defaults
 |`amq_broker_tls_truststore_dest`| Path for installation of truststore | `{{ amq_broker_dest }}/{{ amq_broker_instance_name }}/etc/trust.ks` |
 
 
+* Logging
+
+| Variable | Description | Default |
+|:---------|:------------|:--------|
+|`amq_broker_enable_audit`| Whether to enable audit file logging | `False` |
+|`amq_broker_logger_level`| Root logging level | `INFO` |
+|`amq_broker_logger_core_server_level`| Logging level for org.apache.activemq.artemis.core.server | `INFO` |
+|`amq_broker_logger_journal_level`| Logging level for org.apache.activemq.artemis.journal | `INFO` |
+|`amq_broker_logger_utils_level`| Logging level for org.apache.activemq.artemis.utils | `INFO` |
+|`amq_broker_logger_utils_critical_level`| Logging level for org.apache.activemq.artemis.utils.critical | `INFO` |
+|`amq_broker_logger_jms_level`| Logging level for org.apache.activemq.artemis.jms | `INFO` |
+|`amq_broker_logger_integration_bootstrap_level`| Logging level for org.apache.activemq.artemis.integration.bootstrap | `INFO` |
+|`amq_broker_logger_jetty_level`| Logging level for org.eclipse.jetty | `WARN` |
+|`amq_broker_logger_curator_level`| Logging level for org.apache.curator | `WARN` |
+|`amq_broker_logger_zookeeper_level`| Logging level for org.apache.zookeeper | `ERROR` |
+
+
 * Other options
 
 | Variable | Description | Default |

--- a/roles/amq_broker/defaults/main.yml
+++ b/roles/amq_broker/defaults/main.yml
@@ -87,3 +87,16 @@ amq_broker_disable_amqp_protocol: False
 amq_broker_disable_hornetq_protocol: False
 amq_broker_disable_mqtt_protocol: False
 amq_broker_disable_stomp_protocol: False
+
+# Logging
+amq_broker_enable_audit: False
+amq_broker_logger_level: INFO
+amq_broker_logger_core_server_level: INFO
+amq_broker_logger_journal_level: INFO
+amq_broker_logger_utils_level: INFO
+amq_broker_logger_utils_critical_level: INFO
+amq_broker_logger_jms_level: INFO
+amq_broker_logger_integration_bootstrap_level: INFO
+amq_broker_logger_jetty_level: WARN
+amq_broker_logger_curator_level: WARN
+amq_broker_logger_zookeeper_level: ERROR

--- a/roles/amq_broker/meta/argument_specs.yml
+++ b/roles/amq_broker/meta/argument_specs.yml
@@ -324,42 +324,42 @@ argument_specs:
                 description: "Whether to enable audit file logging"
                 type: "bool"
             amq_broker_logger_level:
-                description: "Whether to enable audit file logging"
+                description: "Root logging level"
                 default: 'INFO'
                 type: "str"
             amq_broker_logger_core_server_level:
-                description: "Whether to enable audit file logging"
+                description: "Logging level for org.apache.activemq.artemis.core.server "
                 default: 'INFO'
                 type: "str"
             amq_broker_logger_journal_level:
-                description: "Whether to enable audit file logging"
+                description: "Logging level for org.apache.activemq.artemis.journal"
                 default: 'INFO'
                 type: "str"
             amq_broker_logger_utils_level:
-                description: "Whether to enable audit file logging"
+                description: "Logging level for org.apache.activemq.artemis.utils"
                 default: 'INFO'
                 type: "str"
             amq_broker_logger_utils_critical_level:
-                description: "Whether to enable audit file logging"
+                description: "Logging level for org.apache.activemq.artemis.utils.critical"
                 default: 'INFO'
                 type: "str"
             amq_broker_logger_jms_level:
-                description: "Whether to enable audit file logging"
+                description: "Logging level for org.apache.activemq.artemis.jms"
                 default: 'INFO'
                 type: "str"
             amq_broker_logger_integration_bootstrap_level:
-                description: "Whether to enable audit file logging"
+                description: "Logging level for org.apache.activemq.artemis.integration.bootstrap"
                 default: 'INFO'
                 type: "str"
             amq_broker_logger_jetty_level:
-                description: "Whether to enable audit file logging"
+                description: "Logging level for org.eclipse.jetty"
                 default: 'WARN'
                 type: "str"
             amq_broker_logger_curator_level:
-                description: "Whether to enable audit file logging"
+                description: "Logging level for org.apache.curator"
                 default: 'WARN'
                 type: "str"
             amq_broker_logger_zookeeper_level:
-                description: "Whether to enable audit file logging"
+                description: "Logging level for org.apache.zookeeper"
                 default: 'ERROR'
                 type: "str"

--- a/roles/amq_broker/meta/argument_specs.yml
+++ b/roles/amq_broker/meta/argument_specs.yml
@@ -319,3 +319,47 @@ argument_specs:
                 default: "{{ amq_broker_rhn_ids[amq_broker_version].id }}"
                 description: "RHN Product ID for Red Hat AMQ Broker"
                 type: "str"
+            amq_broker_enable_audit:
+                default: False
+                description: "Whether to enable audit file logging"
+                type: "bool"
+            amq_broker_logger_level:
+                description: "Whether to enable audit file logging"
+                default: 'INFO'
+                type: "str"
+            amq_broker_logger_core_server_level:
+                description: "Whether to enable audit file logging"
+                default: 'INFO'
+                type: "str"
+            amq_broker_logger_journal_level:
+                description: "Whether to enable audit file logging"
+                default: 'INFO'
+                type: "str"
+            amq_broker_logger_utils_level:
+                description: "Whether to enable audit file logging"
+                default: 'INFO'
+                type: "str"
+            amq_broker_logger_utils_critical_level:
+                description: "Whether to enable audit file logging"
+                default: 'INFO'
+                type: "str"
+            amq_broker_logger_jms_level:
+                description: "Whether to enable audit file logging"
+                default: 'INFO'
+                type: "str"
+            amq_broker_logger_integration_bootstrap_level:
+                description: "Whether to enable audit file logging"
+                default: 'INFO'
+                type: "str"
+            amq_broker_logger_jetty_level:
+                description: "Whether to enable audit file logging"
+                default: 'WARN'
+                type: "str"
+            amq_broker_logger_curator_level:
+                description: "Whether to enable audit file logging"
+                default: 'WARN'
+                type: "str"
+            amq_broker_logger_zookeeper_level:
+                description: "Whether to enable audit file logging"
+                default: 'ERROR'
+                type: "str"

--- a/roles/amq_broker/tasks/configure.yml
+++ b/roles/amq_broker/tasks/configure.yml
@@ -2,12 +2,12 @@
 - name: Create broker cluster node members
   ansible.builtin.set_fact:
     amq_broker_cluster_nodes: >
-      {{ amq_broker_cluster_nodes | default( [] ) + [
+      {{ amq_broker_cluster_nodes | default([]) + [
            {
              "name": amq_broker.instance_name,
              "address": item,
              "inventory_host": item,
-             "value": "tcp://" + item + ":" + (((amq_broker_port|int + amq_broker_ports_offset|int)|abs)|string)
+             "value": "tcp://" + item + ":" + (((amq_broker_port | int + amq_broker_ports_offset | int) | abs) | string)
            }
          ] }}
   loop: "{{ ansible_play_batch }}"
@@ -105,7 +105,7 @@
   ansible.builtin.set_fact:
     amq_broker_options:
       - "{{ amq_broker_options | join(' ') }}"
-      - "--port-offset {{ (0|int + amq_broker_ports_offset|int)|abs }}"
+      - "--port-offset {{ (0 | int + amq_broker_ports_offset | int) | abs }}"
   when: amq_broker_ports_offset_enabled
 
 - name: Disable AMQP protocol

--- a/roles/amq_broker/tasks/systemd.yml
+++ b/roles/amq_broker/tasks/systemd.yml
@@ -44,12 +44,6 @@
   when:
     - not instance_directory.stat.exists
 
-- name: "Setup clustering with jgroups"
-  ansible.builtin.include_tasks: jgroups.yml
-  when:
-    - amq_broker_ha_enabled
-    - amq_broker_cluster_discovery == 'jgroups'
-
 - name: "Create instance {{ amq_broker.instance_name }} of {{ amq_broker.service_name }}"
   ansible.builtin.command:
     cmd: "{{ amq_broker.home }}/bin/artemis create {{ amq_broker.instance_home }} {{ amq_broker_options }}"
@@ -58,6 +52,23 @@
   register: broker_created
   when:
     - not instance_directory.stat.exists
+
+- name: "Setup clustering with jgroups"
+  ansible.builtin.include_tasks: jgroups.yml
+  when:
+    - amq_broker_ha_enabled
+    - amq_broker_cluster_discovery == 'jgroups'
+
+- name: "Configure AMQ broker logging"
+  become: yes
+  ansible.builtin.template:
+    src: logging.properties.j2
+    dest: "{{ amq_broker.instance_home }}/etc/logging.properties"
+    owner: "{{ amq_broker_service_user }}"
+    group: "{{ amq_broker_service_group }}"
+    mode: 0644
+  notify:
+    - restart amq_broker
 
 - name: Reload systemd
   become: yes

--- a/roles/amq_broker/templates/logging.properties.j2
+++ b/roles/amq_broker/templates/logging.properties.j2
@@ -1,0 +1,75 @@
+# {{ ansible_managed }}
+# Additional logger names to configure (root logger is always configured)
+# Root logger option
+loggers=org.eclipse.jetty,org.jboss.logging,org.apache.activemq.artemis.core.server,org.apache.activemq.artemis.utils,org.apache.activemq.artemis.utils.critical,org.apache.activemq.artemis.journal,org.apache.activemq.artemis.jms.server,org.apache.activemq.artemis.integration.bootstrap,org.apache.activemq.audit.base,org.apache.activemq.audit.message,org.apache.activemq.audit.resource,org.apache.curator,org.apache.zookeeper
+
+# Root logger level
+logger.level={{ amq_broker_logger_level }}
+
+# ActiveMQ Artemis logger levels
+logger.org.apache.activemq.artemis.core.server.level={{ amq_broker_logger_core_server_level }}
+logger.org.apache.activemq.artemis.journal.level={{ amq_broker_logger_journal_level }}
+logger.org.apache.activemq.artemis.utils.level={{ amq_broker_logger_utils_level }}
+
+# if you have issues with CriticalAnalyzer, setting this as TRACE would give you extra troubleshooting information.
+# but do not use it regularly as it would incur in some extra CPU usage for this diagnostic.
+logger.org.apache.activemq.artemis.utils.critical.level={{ amq_broker_logger_utils_critical_level }}
+
+logger.org.apache.activemq.artemis.jms.level={{ amq_broker_logger_jms_level }}
+logger.org.apache.activemq.artemis.integration.bootstrap.level={{ amq_broker_logger_integration_bootstrap_level }}
+logger.org.eclipse.jetty.level={{ amq_broker_logger_jetty_level }}
+# Root logger handlers
+logger.handlers=FILE,CONSOLE
+
+# quorum logger levels
+logger.org.apache.curator.level={{ amq_broker_logger_curator_level }}
+logger.org.apache.zookeeper.level={{ amq_broker_logger_zookeeper_level }}
+
+# to enable audit change the level to INFO
+logger.org.apache.activemq.audit.base.level={{ 'ERROR' if amq_broker_enable_audit else 'INFO' }}
+logger.org.apache.activemq.audit.base.handlers=AUDIT_FILE
+logger.org.apache.activemq.audit.base.useParentHandlers=false
+
+logger.org.apache.activemq.audit.resource.level={{ 'ERROR' if amq_broker_enable_audit else 'INFO' }}
+logger.org.apache.activemq.audit.resource.handlers=AUDIT_FILE
+logger.org.apache.activemq.audit.resource.useParentHandlers=false
+
+logger.org.apache.activemq.audit.message.level={{ 'ERROR' if amq_broker_enable_audit else 'INFO' }}
+logger.org.apache.activemq.audit.message.handlers=AUDIT_FILE
+logger.org.apache.activemq.audit.message.useParentHandlers=false
+
+# Console handler configuration
+handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
+handler.CONSOLE.properties=autoFlush
+handler.CONSOLE.level=DEBUG
+handler.CONSOLE.autoFlush=true
+handler.CONSOLE.formatter=PATTERN
+
+# File handler configuration
+handler.FILE=org.jboss.logmanager.handlers.PeriodicRotatingFileHandler
+handler.FILE.level=DEBUG
+handler.FILE.properties=suffix,append,autoFlush,fileName
+handler.FILE.suffix=.yyyy-MM-dd
+handler.FILE.append=true
+handler.FILE.autoFlush=true
+handler.FILE.fileName=${artemis.instance}/log/artemis.log
+handler.FILE.formatter=PATTERN
+
+# Formatter pattern configuration
+formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+formatter.PATTERN.properties=pattern
+formatter.PATTERN.pattern=%d %-5p [%c] %s%E%n
+
+#Audit logger
+handler.AUDIT_FILE=org.jboss.logmanager.handlers.PeriodicRotatingFileHandler
+handler.AUDIT_FILE.level=INFO
+handler.AUDIT_FILE.properties=suffix,append,autoFlush,fileName
+handler.AUDIT_FILE.suffix=.yyyy-MM-dd
+handler.AUDIT_FILE.append=true
+handler.AUDIT_FILE.autoFlush=true
+handler.AUDIT_FILE.fileName=${artemis.instance}/log/audit.log
+handler.AUDIT_FILE.formatter=AUDIT_PATTERN
+
+formatter.AUDIT_PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+formatter.AUDIT_PATTERN.properties=pattern
+formatter.AUDIT_PATTERN.pattern=%d [AUDIT](%t) %s%E%n


### PR DESCRIPTION
New variables:

| Variable | Description | Default |
|:---------|:------------|:--------|
|`amq_broker_enable_audit`| Whether to enable audit file logging | `False` |
|`amq_broker_logger_level`| Root logging level | `INFO` |
|`amq_broker_logger_core_server_level`| Logging level for org.apache.activemq.artemis.core.server | `INFO` |
|`amq_broker_logger_journal_level`| Logging level for org.apache.activemq.artemis.journal | `INFO` |
|`amq_broker_logger_utils_level`| Logging level for org.apache.activemq.artemis.utils | `INFO` |
|`amq_broker_logger_utils_critical_level`| Logging level for org.apache.activemq.artemis.utils.critical | `INFO` |
|`amq_broker_logger_jms_level`| Logging level for org.apache.activemq.artemis.jms | `INFO` |
|`amq_broker_logger_integration_bootstrap_level`| Logging level for org.apache.activemq.artemis.integration.bootstrap | `INFO` |
|`amq_broker_logger_jetty_level`| Logging level for org.eclipse.jetty | `WARN` |
|`amq_broker_logger_curator_level`| Logging level for org.apache.curator | `WARN` |
|`amq_broker_logger_zookeeper_level`| Logging level for org.apache.zookeeper | `ERROR` |