### PR TITLE
Variable to config controller download/offline directory

### DIFF
--- a/molecule/amq_upgrade/verify.yml
+++ b/molecule/amq_upgrade/verify.yml
@@ -4,7 +4,7 @@
   tasks:
     - name: Check local download archive path
       ansible.builtin.stat:
-        path: "{{ activemq_local_archive_repository }}"
+        path: "{{ lookup('env', 'PWD') }}"
       register: local_path
       delegate_to: localhost    
     - name: Check archive for 7.9.4

--- a/molecule/amq_upgrade/verify.yml
+++ b/molecule/amq_upgrade/verify.yml
@@ -4,7 +4,7 @@
   tasks:
     - name: Check local download archive path
       ansible.builtin.stat:
-        path: "{{ lookup('env', 'PWD') }}"
+        path: "{{ activemq_local_archive_repository }}"
       register: local_path
       delegate_to: localhost    
     - name: Check archive for 7.9.4

--- a/roles/amq_broker/README.md
+++ b/roles/amq_broker/README.md
@@ -36,6 +36,7 @@ Role Defaults
 |`activemq_installdir`| Apache Artemis Installation path | `{{ activemq_dest }}/apache-artemis-{{ activemq_version }}` |
 |`activemq_dest`| Root installation directory | `/opt/amq` |
 |`activemq_offline_install`| Perform an offline installation | `False` |
+|`activemq_local_archive_repository`| Path local to controller for offline/download of install archives | `{{ lookup('env', 'PWD') }}` |
 
 
 * Common configuration

--- a/roles/amq_broker/defaults/main.yml
+++ b/roles/amq_broker/defaults/main.yml
@@ -116,3 +116,6 @@ activemq_jmx_exporter_port: 18080
 activemq_jmx_exporter_config_path: "{{ activemq_dest }}/{{ activemq_instance_name }}/etc/jmx_exporter.yml"
 activemq_jmx_exporter_enabled: False
 activemq_prometheus_enabled: False
+
+### Contoller defaults
+activemq_local_archive_repository: "{{ lookup('env', 'PWD') }}"

--- a/roles/amq_broker/meta/argument_specs.yml
+++ b/roles/amq_broker/meta/argument_specs.yml
@@ -351,12 +351,16 @@ argument_specs:
                 default: "Administrative role 'amq'"
                 type: "list"
             activemq_name:
-                description: 'TODO'
+                description: 'Human friendly name for service'
                 default: "Apache ActiveMQ"
                 type: "str"
             activemq_service_name:
-                description: "TODO"
+                description: "Systemd unit name"
                 default: "activemq"
+                type: "str"
+            activemq_local_archive_repository:
+                description: "Path local to controller for offline/download of install archives"
+                default: "{{ lookup('env', 'PWD') }}"
                 type: "str"
     downstream:
         options:
@@ -395,10 +399,10 @@ argument_specs:
                 description: "RHN Product ID for Red Hat AMQ Broker"
                 type: "str"
             amq_broker_name:
-                description: 'TODO'
+                description: "Human friendly name for service"
                 default: "Red Hat AMQ Broker"
                 type: "str"
-            aamq_broker_service_name:
-                description: "TODO"
+            amq_broker_service_name:
+                description: "Systemd unit name"
                 default: "amq_broker"
                 type: "str"

--- a/roles/amq_broker/tasks/install.yml
+++ b/roles/amq_broker/tasks/install.yml
@@ -56,7 +56,7 @@
 ## download to controller
 - name: Check local download archive path
   ansible.builtin.stat:
-    path: "{{ lookup('env', 'PWD') }}"
+    path: "{{ activemq_local_archive_repository }}"
   register: local_path
   delegate_to: localhost
 


### PR DESCRIPTION
New variable `activemq_local_archive_repository` configures a directory accessible from controller to use for downloading/installing provided install archives. Default is `ansible-playbook` command `$PWD` (as previously set) so no change is necessary if the config is not used.