### PR TITLE
Allow to list roles for users, specify security setting match address

### DIFF
--- a/molecule/amq_upgrade/converge.yml
+++ b/molecule/amq_upgrade/converge.yml
@@ -8,7 +8,7 @@
     activemq_users:
     - user: amq
       password: amqbrokerpass
-      role: admin
+      roles: [ amq ]
   collections:
     - middleware_automation.redhat_csp_download
   tasks:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,9 +4,21 @@
   gather_facts: yes
   vars:
     activemq_users:
-    - user: amq
-      password: amqbrokerpass
-      role: admin
+      - user: amq
+        password: amqbrokerpass
+        roles: [ admin ]
+      - user: other
+        password: amqotherpass
+        roles: [ consumer, producer ]
+    activemq_roles:
+      - name: admin
+        permissions: [ createNonDurableQueue, deleteNonDurableQueue, createDurableQueue, deleteDurableQueue, createAddress, deleteAddress, consume, browse, send, manage ]
+      - name: consumer
+        match: topics.#
+        permissions: [ consume, browse ]
+      - name: producer
+        match: topics.#
+        permissions: [ send, browse ]
   collections:
     - middleware_automation.redhat_csp_download
   roles:

--- a/roles/amq_broker/defaults/main.yml
+++ b/roles/amq_broker/defaults/main.yml
@@ -64,17 +64,19 @@ activemq_tls_truststore_password:
 activemq_tls_truststore_dest: "{{ activemq_dest }}/{{ activemq_instance_name }}/etc/trust.ks"
 
 # Users
-# list of users the create, user is not created if password empty; list of (user,password,role) dicts
+# list of users the create, user is not created if password empty; list of (user,password,roles) dicts
+# .roles is a list of activemq_roles.name
 activemq_users:
   - user: "{{ activemq_instance_username }}"
     password: "{{ activemq_instance_password }}"
-    role: amq
+    roles: [ amq ]
 
 # Roles
 # .permissions is subset of:
 # [ createNonDurableQueue, deleteNonDurableQueue, createDurableQueue, deleteDurableQueue, createAddress, deleteAddress, consume, browse, send, manage ]
 activemq_roles:
   - name: amq
+    match: '#'
     permissions: [ createNonDurableQueue, deleteNonDurableQueue, createDurableQueue, deleteDurableQueue, createAddress, deleteAddress, consume, browse, send, manage ]
 
 # NIO option

--- a/roles/amq_broker/meta/argument_specs.yml
+++ b/roles/amq_broker/meta/argument_specs.yml
@@ -343,7 +343,7 @@ argument_specs:
                 default: False
                 type: "bool"
             activemq_users:
-                description: "List of users the create with role; user is not created if password empty. List of (user,password,role) dicts"
+                description: "List of users to create with roles; user is not created if password empty. List of (user,password,roles) dicts"
                 default: "{{ activemq_instance_username }}/{{ activemq_instance_password }} with default admin 'amq' role"
                 type: "list"
             activemq_roles:

--- a/roles/amq_broker/tasks/mask_password.yml
+++ b/roles/amq_broker/tasks/mask_password.yml
@@ -8,6 +8,6 @@
       no_log: True
     - name: Add masked password to users list
       ansible.builtin.set_fact:
-        activemq_masked_users: "{{ activemq_masked_users | default([]) + [{ 'user': item.user, 'password': mask_pwd.stdout | replace('result: ',''), 'role': item.role }] }}"
+        activemq_masked_users: "{{ activemq_masked_users | default([]) + [{ 'user': item.user, 'password': mask_pwd.stdout | replace('result: ',''), 'roles': item.roles }] }}"
       no_log: True
       when: item.password is defined and item.password | length > 0

--- a/roles/amq_broker/tasks/user_roles.yml
+++ b/roles/amq_broker/tasks/user_roles.yml
@@ -22,15 +22,18 @@
     group: "{{ activemq_service_group }}"
     mode: 0640
 
+- name: Create security settings
+  ansible.builtin.set_fact:
+    security_settings: "{{ security_settings | default([]) + [ lookup('template', 'security_settings.broker.xml.j2') ] }}"
+  loop: "{{ activemq_roles }}"
+
 - name: Create messaging roles permissions
   xml:
     path: "{{ activemq.instance_home }}/etc/broker.xml"
     xpath: /conf:configuration/core:core/core:security-settings
     input_type: xml
-    add_children: "{{ lookup('template', 'security_settings.broker.xml.j2') }}"
+    set_children: "{{ security_settings }}"
     namespaces:
       conf: urn:activemq
       core: urn:activemq:core
     pretty_print: yes
-  changed_when: False
-  loop: "{{ activemq_roles }}"

--- a/roles/amq_broker/templates/artemis-roles.properties.j2
+++ b/roles/amq_broker/templates/artemis-roles.properties.j2
@@ -16,6 +16,6 @@
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
 
-{% for user in activemq_masked_users %}
-{{ user.user }} = {{ user.role }}
+{% for role in activemq_roles %}
+{{ role.name }}={{ activemq_users | selectattr('roles','issuperset',[ role.name ]) | list | map(attribute='user') | list | join(',') }}
 {% endfor %}

--- a/roles/amq_broker/templates/security_settings.broker.xml.j2
+++ b/roles/amq_broker/templates/security_settings.broker.xml.j2
@@ -1,5 +1,5 @@
-    <security-setting match="#">
-    {% for permission in item.permissions %}
-    <permission type="{{ permission }}" roles="{{ item.name }}"/>
-    {% endfor %}
+    <security-setting match="{{ item.match | default('#') }}">
+{% for permission in item.permissions %}
+        <permission type="{{ permission }}" roles="{{ item.name }}"/>
+{% endfor %}
     </security-setting>


### PR DESCRIPTION
Fix #12 
Fix #16 

While this changeset originates from a bug report, the solution involves refactoring the key in the `activemq_users` dictionary from `role: str` to `roles: list(str)`, thus it is marked as major_change