### PR TITLE
Add systemd RequiresMountsFor and unit custom template

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -24,12 +24,12 @@ warn_list:
   - fqcn-builtins
   - no-log-password
   - no-empty-data-files
-  - jinja[spacing]
   - name[template]
 
 skip_list:
   - vars_should_not_be_used
   - file_is_small_enough
+  - jinja[spacing]
 
 use_default_rules: true
 parseable: true

--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -75,6 +75,7 @@ Role Defaults
 |`activemq_ports_offset`| Port offset for all default ports | `0` |
 |`activemq_shared_storage`| Use shared filesystem directory for storage | `False` |
 |`activemq_shared_storage_path`| Absolute path of shared directory | `{{ activemq_dest }}/{{ activemq_instance_name }}/data/shared` |
+|`activemq_shared_storage_mounted`| Whether the systemd unit must require a mounted path (only when using shared storage) | `True` |
 |`activemq_disable_destination_autocreate`| Disable automatic creation of destination | `True` |
 |`activemq_queues`| Queue names comma separated | `queue.in,queue.out` |
 
@@ -183,7 +184,8 @@ See _Role Variables_ below for additional TLS/SSL settings.
 |`activemq_db_enabled`| Whether to enable JDBC persistence | `False` |
 |`activemq_config_dir`| Broker instance configuration directory | `conf` |
 |`activemq_config_xml`| Broker instance configuration file | `amq-broker.xml` |
-|`activemq_config_override_template`| TODO document argument | `TODO` |
+|`activemq_config_override_template`| Filename of custom broker xml configuration file to be deployed | `` |
+|`activemq_service_override_template`| Filename of custom systemd unit template to be deployed | `` |
 
 
 * User / Role configuration

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -41,6 +41,7 @@ activemq_port_mqtt: 1883    # for protocols [MQTT]
 activemq_port_stomp: 61613  # for protocols [STOMP]
 activemq_name: 'Apache ActiveMQ'
 activemq_service_name: activemq
+activemq_service_override_template: ''
 
 ### Enable configuration for high availability
 activemq_ha_enabled: False
@@ -105,6 +106,7 @@ activemq_nio_enabled: False
 
 ## Shared Storage
 activemq_shared_storage: False
+activemq_shared_storage_mounted: True
 activemq_shared_storage_path: "{{ activemq_dest }}/{{ activemq_instance_name }}/data/shared"
 
 ## Ports

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -37,7 +37,7 @@ argument_specs:
             activemq_config_override_template:
                 # line 19 of defaults/main.yml
                 default: ""
-                description: "TODO document argument"
+                description: "Filename of custom broker xml configuration file to be deployed"
                 type: "str"
             activemq_service_user:
                 # line 20 of defaults/main.yml
@@ -242,6 +242,10 @@ argument_specs:
                 default: "{{ activemq_dest }}/{{ activemq_instance_name }}/data/shared"
                 description: "Absolute path of shared directory"
                 type: "str"
+            activemq_shared_storage_mounted:
+                default: True
+                description: "Whether the systemd unit must require a mounted path (only when using shared storage)"
+                type: "bool"
             activemq_ports_offset_enabled:
                 # line 75 of defaults/main.yml
                 default: false
@@ -390,6 +394,10 @@ argument_specs:
                 description: "Connectors configuration; list of `{ name, address, port, parameters(dict) }`"
                 default: "Generate same configuration as `artemis create`"
                 type: "list"
+            activemq_service_override_template:
+                description: "Filename of custom systemd unit template to be deployed"
+                default: ""
+                type: "str"
     downstream:
         options:
             amq_broker_version:

--- a/roles/activemq/tasks/systemd.yml
+++ b/roles/activemq/tasks/systemd.yml
@@ -23,7 +23,7 @@
 
 - name: "Configure systemd unit file for {{ activemq.instance_name }} {{ activemq.service_name }} service"
   ansible.builtin.template:
-    src: amq_broker.service.j2
+    src: "{{ activemq_service_override_template | default('amq_broker.service.j2', true) }}"
     dest: "/etc/systemd/system/{{ activemq.instance_name }}.service"
     owner: root
     group: root
@@ -126,7 +126,7 @@
 
 - name: "Configure prometheus metrics"
   become: yes
-  when: activemq_prometheus_enabled
+  when: activemq_prometheus_enabled and amq_broker_enable is defined and amq_broker_enable
   block:
     - name: Ensure lib is available to instance
       ansible.builtin.copy:

--- a/roles/activemq/templates/amq_broker.service.j2
+++ b/roles/activemq/templates/amq_broker.service.j2
@@ -2,6 +2,9 @@
 [Unit]
 Description={{ activemq.instance_name }} {{ activemq.name }} Service
 After=network.target
+{% if activemq_shared_storage and activemq_shared_storage_mounted %}
+RequiresMountsFor={{ activemq_shared_storage_path }}
+{% endif %}
 
 [Service]
 Type=forking


### PR DESCRIPTION
Fix #35 

This change adds `RequiresMountsFor=` to the systemd unit when shared storage is used (activemq_shared_storage=True). A new variable `activemq_shared_storage_mounted` (default True), allows to avoid this behaviour (ie. the shared file system is local, instances are colocated).

As an alternative it is also now possible to override the systemd configuration with a custom template, to be passed-in via the new variable `activemq_service_override_template` (default: ''). The file pointed by the filename should be made available in the ansible playbook template lookup directories.

| Variable | Description | Default |
|:---------|:------------|:--------|
|`activemq_shared_storage_mounted`| Whether the systemd unit must require a mounted path (only when using shared storage) | `True` |
|`activemq_service_override_template`| Filename of custom systemd unit template to be deployed | `` |