### PR TITLE
Add configuration variables for address settings

### DIFF
--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -151,6 +151,29 @@ Sample connector with TLS:
 ```
 
 
+* Address settings
+
+| Variable | Description | Default |
+|:---------|:------------|:--------|
+|`activemq_address_settings`| Address settings configuration; list of `{ match address string and parameters }` | "Generate same configuration as `artemis create`" |
+
+Sample address settings:
+
+```
+  - match: activemq.management#
+    dead_letter_address: DLQ
+    expiry_address: ExpiryQueue
+    redelivery_delay: 0
+    max_size_bytes: -1
+    message_counter_history_day_limit: 10
+    address_full_policy: PAGE
+    auto_create_queues: true
+    auto_create_addresses: true
+    auto_create_jms_queues: true
+    auto_create_jms_topics: true
+```
+
+
 * Clustering
 
 | Variable | Description | Default |

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -237,3 +237,30 @@ activemq_connectors:
       amqpMinLargeMessageSize: 102400
       supportAdvisory: false
       suppressInternalManagementObjects: false
+
+### Address settings configuration
+activemq_address_settings:
+  - match: activemq.management#
+    dead_letter_address: DLQ
+    expiry_address: ExpiryQueue
+    redelivery_delay: 0
+    max_size_bytes: -1
+    message_counter_history_day_limit: 10
+    address_full_policy: PAGE
+    auto_create_queues: true
+    auto_create_addresses: true
+    auto_create_jms_queues: true
+    auto_create_jms_topics: true
+  - match: #
+    dead_letter_address: DLQ
+    expiry_address: ExpiryQueue
+    redelivery_delay: 0
+    max_size_bytes: -1
+    message_counter_history_day_limit: 10
+    address_full_policy: PAGE
+    auto_create_queues: false
+    auto_create_addresses: false
+    auto_create_jms_queues: false
+    auto_create_jms_topics: false
+    auto_delete_queues: false
+    auto_delete_addresses: false

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -394,6 +394,10 @@ argument_specs:
                 description: "Connectors configuration; list of `{ name, address, port, parameters(dict) }`"
                 default: "Generate same configuration as `artemis create`"
                 type: "list"
+            activemq_address_settings:
+                description: "Address settings configuration; list of `{ match address string and parameters }`"
+                default: "Generate same configuration as `artemis create`"
+                type: "list"
             activemq_service_override_template:
                 description: "Filename of custom systemd unit template to be deployed"
                 default: ""

--- a/roles/activemq/tasks/address_settings.yml
+++ b/roles/activemq/tasks/address_settings.yml
@@ -1,0 +1,22 @@
+---
+- name: Create address settings configuration string
+  ansible.builtin.set_fact:
+    address_settings: "{{ address_settings | default([]) + [ lookup('template', 'address_settings.broker.xml.j2') ] }}"
+  loop: "{{ activemq_address_settings }}"
+  loop_control:
+    loop_var: address_setting
+    label: "{{ address_setting.match }}"
+
+- name: Create address settings configuration in broker.xml
+  community.general.xml:
+    path: "{{ activemq.instance_home }}/etc/broker.xml"
+    xpath: /conf:configuration/core:core/core:address-settings
+    input_type: xml
+    set_children: "{{ address_settings }}"
+    namespaces:
+      conf: urn:activemq
+      core: urn:activemq:core
+    pretty_print: yes
+  become: yes
+  notify:
+    - restart amq_broker

--- a/roles/activemq/tasks/configure_broker.yml
+++ b/roles/activemq/tasks/configure_broker.yml
@@ -27,6 +27,10 @@
 - name: Configure journal
   ansible.builtin.include_tasks: journal.yml
 
+- name: Configure address settings
+  ansible.builtin.include_tasks: address_settings.yml
+  when: activemq_address_settings | length > 0
+
 - name: "Configure jolokia access"
   become: yes
   ansible.builtin.template:
@@ -73,5 +77,5 @@
         - restart amq_broker
   rescue:
     - name: Report metrics plugin failure
-      debug:
+      ansible.builtin.debug:
         msg: "Could not install prometheus metrics plugin because the installation zipfile does not provide it"

--- a/roles/activemq/tasks/connectors.yml
+++ b/roles/activemq/tasks/connectors.yml
@@ -23,20 +23,25 @@
   notify:
     - restart amq_broker
 
-- name: Create cluster connections configuration string
-  ansible.builtin.set_fact:
-    cluster_connections: "{{ lookup('template', 'cluster_connections.broker.xml.j2') }}"
+- name: Configure static cluster
+  when:
+    - activemq_cluster_discovery == 'static'
+    - activemq_ha_enabled
+  block:
+    - name: Create cluster connections configuration string
+      ansible.builtin.set_fact:
+        cluster_connections: "{{ lookup('template', 'cluster_connections.broker.xml.j2') }}"
 
-- name: Create cluster connections in broker.xml
-  community.general.xml:
-    path: "{{ activemq.instance_home }}/etc/broker.xml"
-    xpath: /conf:configuration/core:core/core:cluster-connections
-    input_type: xml
-    set_children: "{{ cluster_connections }}"
-    namespaces:
-      conf: urn:activemq
-      core: urn:activemq:core
-    pretty_print: yes
-  become: yes
-  notify:
-    - restart amq_broker
+    - name: Create cluster connections in broker.xml
+      community.general.xml:
+        path: "{{ activemq.instance_home }}/etc/broker.xml"
+        xpath: /conf:configuration/core:core/core:cluster-connections
+        input_type: xml
+        set_children: "{{ cluster_connections }}"
+        namespaces:
+          conf: urn:activemq
+          core: urn:activemq:core
+        pretty_print: yes
+      become: yes
+      notify:
+        - restart amq_broker

--- a/roles/activemq/tasks/connectors.yml
+++ b/roles/activemq/tasks/connectors.yml
@@ -22,3 +22,21 @@
   no_log: True
   notify:
     - restart amq_broker
+
+- name: Create cluster connections configuration string
+  ansible.builtin.set_fact:
+    cluster_connections: "{{ lookup('template', 'cluster_connections.broker.xml.j2') }}"
+
+- name: Create cluster connections in broker.xml
+  community.general.xml:
+    path: "{{ activemq.instance_home }}/etc/broker.xml"
+    xpath: /conf:configuration/core:core/core:cluster-connections
+    input_type: xml
+    set_children: "{{ cluster_connections }}"
+    namespaces:
+      conf: urn:activemq
+      core: urn:activemq:core
+    pretty_print: yes
+  become: yes
+  notify:
+    - restart amq_broker

--- a/roles/activemq/templates/address_settings.broker.xml.j2
+++ b/roles/activemq/templates/address_settings.broker.xml.j2
@@ -1,0 +1,14 @@
+         <address-setting match="{{ address_setting.match }}">
+            <dead-letter-address>{{ address_setting.dead_letter_address }}</dead-letter-address>
+            <expiry-address>{{ address_setting.expiry_address }}</expiry-address>
+            <redelivery-delay>{{ address_setting.redelivery_delay }}</redelivery-delay>
+            <max-size-bytes>{{ address_setting.max_size_bytes }}</max-size-bytes>
+            <message-counter-history-day-limit>{{ address_setting.message_counter_history_day_limit }}</message-counter-history-day-limit>
+            <address-full-policy>{{ address_setting.address_full_policy }}</address-full-policy>
+            <auto-create-queues>{{ address_setting.auto_create_queues }}</auto-create-queues>
+            <auto-create-addresses>{{ address_setting.auto_create_addresses }}</auto-create-addresses>
+            <auto-create-jms-queues>{{ address_setting.auto_create_jms_queues }}</auto-create-jms-queues>
+            <auto-create-jms-topics>{{ address_setting.auto_create_jms_topics }}</auto-create-jms-topics>
+            <auto-delete-queues>{{ address_setting.auto_delete_queues }}</auto-delete-queues>
+            <auto-delete-addresses>{{ address_setting.auto_delete_addresses }}</auto-delete-addresses>
+         </address-setting>

--- a/roles/activemq/templates/address_settings.broker.xml.j2
+++ b/roles/activemq/templates/address_settings.broker.xml.j2
@@ -1,14 +1,15 @@
          <address-setting match="{{ address_setting.match }}">
             <dead-letter-address>{{ address_setting.dead_letter_address }}</dead-letter-address>
             <expiry-address>{{ address_setting.expiry_address }}</expiry-address>
-            <redelivery-delay>{{ address_setting.redelivery_delay }}</redelivery-delay>
-            <max-size-bytes>{{ address_setting.max_size_bytes }}</max-size-bytes>
-            <message-counter-history-day-limit>{{ address_setting.message_counter_history_day_limit }}</message-counter-history-day-limit>
+            <redelivery-delay>{{ address_setting.redelivery_delay | default(0) }}</redelivery-delay>
+            <max-size-bytes>{{ address_setting.max_size_bytes | default(-1) }}</max-size-bytes>
+            <message-counter-history-day-limit>{{ address_setting.message_counter_history_day_limit | default(0) }}</message-counter-history-day-limit>
             <address-full-policy>{{ address_setting.address_full_policy }}</address-full-policy>
-            <auto-create-queues>{{ address_setting.auto_create_queues }}</auto-create-queues>
-            <auto-create-addresses>{{ address_setting.auto_create_addresses }}</auto-create-addresses>
-            <auto-create-jms-queues>{{ address_setting.auto_create_jms_queues }}</auto-create-jms-queues>
-            <auto-create-jms-topics>{{ address_setting.auto_create_jms_topics }}</auto-create-jms-topics>
-            <auto-delete-queues>{{ address_setting.auto_delete_queues }}</auto-delete-queues>
-            <auto-delete-addresses>{{ address_setting.auto_delete_addresses }}</auto-delete-addresses>
+            <auto-create-queues>{{ address_setting.auto_create_queues | default('true') | lower }}</auto-create-queues>
+            <auto-create-addresses>{{ address_setting.auto_create_addresses | default('true') | lower }}</auto-create-addresses>
+            <auto-create-jms-queues>{{ address_setting.auto_create_jms_queues | default('true') | lower }}</auto-create-jms-queues>
+            <auto-create-jms-topics>{{ address_setting.auto_create_jms_topics | default('true') | lower }}</auto-create-jms-topics>
+            <auto-create-dead-letter-resources>{{ address_setting.auto_create_dead_letter_resources | default('false') | lower }}</auto-create-dead-letter-resources>
+            <auto-delete-queues>{{ address_setting.auto_delete_queues | default('true') | lower }}</auto-delete-queues>
+            <auto-delete-addresses>{{ address_setting.auto_delete_addresses | default('true') | lower }}</auto-delete-addresses>
          </address-setting>

--- a/roles/activemq/templates/cluster_connections.broker.xml.j2
+++ b/roles/activemq/templates/cluster_connections.broker.xml.j2
@@ -1,6 +1,6 @@
          <cluster-connection name="{{ activemq_service_name }}">
-            <connector-ref>{% for param in amq_broker_connectors %}{% if param.address == localhost or param.address == inventory_hostname %}{{ param.name }}{% endif %}{% endfor %}</connector-ref>
+            <connector-ref>{% for param in activemq_connectors %}{% if param.address == 'localhost' or param.address == inventory_hostname %}{{ param.name }}{% endif %}{% endfor %}</connector-ref>
             <static-connectors>
-               {% for param in amq_broker_connectors %}<connector-ref>{{ param.name }}</connector-ref>{% endfor %}
+               {% for param in activemq_connectors %}<connector-ref>{{ param.name }}</connector-ref>{% endfor %}
             </static-connectors>
          </cluster-connection>

--- a/roles/activemq/templates/cluster_connections.broker.xml.j2
+++ b/roles/activemq/templates/cluster_connections.broker.xml.j2
@@ -1,0 +1,6 @@
+         <cluster-connection name="{{ activemq_service_name }}">
+            <connector-ref>{% for param in amq_broker_connectors %}{% if param.address == localhost or param.address == inventory_hostname %}{{ param.name }}{% endif %}{% endfor %}</connector-ref>
+            <static-connectors>
+               {% for param in amq_broker_connectors %}<connector-ref>{{ param.name }}</connector-ref>{% endfor %}
+            </static-connectors>
+         </cluster-connection>


### PR DESCRIPTION
* Address settings

| Variable | Description | Default |
|:---------|:------------|:--------|
|`activemq_address_settings`| Address settings configuration; list of `{ match address string and parameters }` | Generate same configuration as `artemis create` |

Sample address settings:

```
  - match: activemq.management#
    dead_letter_address: DLQ
    expiry_address: ExpiryQueue
    redelivery_delay: 0
    max_size_bytes: -1
    message_counter_history_day_limit: 10
    address_full_policy: PAGE
    auto_create_queues: true
    auto_create_addresses: true
    auto_create_jms_queues: true
    auto_create_jms_topics: true
```
