### PR TITLE
New flags make systemd unit wait for activemq ports or logs

### DIFF
--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -186,6 +186,7 @@ Sample address settings:
 |`activemq_replicate`| Enables replication | `False` |
 |`activemq_replicated`| Designate instance as replicated node | `False` |
 |`activemq_cluster_discovery` | Cluster discovery: [`jgroups` (shared file ping), `multicast` (UDP), `static` (node list)] | `static` |
+|`activemq_systemd_wait_for_port` | Whether systemd unit should wait for activemq port before returning | `True` when activemq_ha_enabled is `True` |
 
 
 * TLS/SSL protocol

--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -186,7 +186,8 @@ Sample address settings:
 |`activemq_replicate`| Enables replication | `False` |
 |`activemq_replicated`| Designate instance as replicated node | `False` |
 |`activemq_cluster_discovery` | Cluster discovery: [`jgroups` (shared file ping), `multicast` (UDP), `static` (node list)] | `static` |
-|`activemq_systemd_wait_for_port` | Whether systemd unit should wait for activemq port before returning | `True` when activemq_ha_enabled is `True` |
+|`activemq_systemd_wait_for_port` | Whether systemd unit should wait for activemq port before returning | `True` when activemq_ha_enabled is `True` and activemq_shared_storage is `False` |
+|`activemq_systemd_wait_for_log` | Whether systemd unit should wait for service to be up in logs | `True` when activemq_ha_enabled and activemq_shared_storage are `True` |
 
 
 * TLS/SSL protocol

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -53,6 +53,7 @@ activemq_replicate: False
 activemq_replicated: False
 # cluster discovery: ['jgroups' for shared file ping, 'multicast' for UDP multicast, 'static' for static declaration]
 activemq_cluster_discovery: static
+activemq_systemd_wait_for_port: "{{ activemq_ha_enabled }}"
 
 ### Enable persistence and persistence options
 activemq_persistence_enabled: True

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -53,7 +53,8 @@ activemq_replicate: False
 activemq_replicated: False
 # cluster discovery: ['jgroups' for shared file ping, 'multicast' for UDP multicast, 'static' for static declaration]
 activemq_cluster_discovery: static
-activemq_systemd_wait_for_port: "{{ activemq_ha_enabled }}"
+activemq_systemd_wait_for_port: "{{ activemq_ha_enabled and not activemq_shared_storage }}"
+activemq_systemd_wait_for_log: "{{ activemq_ha_enabled and activemq_shared_storage }}"
 
 ### Enable persistence and persistence options
 activemq_persistence_enabled: True

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -482,6 +482,10 @@ argument_specs:
                 description: 'The fully qualified class name of the desired database Driver'
                 default: 'org.apache.derby.jdbc.EmbeddedDriver'
                 type: "str"
+            activemq_systemd_wait_for_port:
+                description: 'Whether systemd unit should wait for activemq port before returning'
+                default: "{{ activemq_ha_enabled }}"
+                type: 'bool'
     downstream:
         options:
             amq_broker_version:

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -484,7 +484,11 @@ argument_specs:
                 type: "str"
             activemq_systemd_wait_for_port:
                 description: 'Whether systemd unit should wait for activemq port before returning'
-                default: "{{ activemq_ha_enabled }}"
+                default: "{{ activemq_ha_enabled and not activemq_shared_storage }}"
+                type: 'bool'
+            activemq_systemd_wait_for_port:
+                description: 'Whether systemd unit should wait for service to be up in logs'
+                default: "{{ activemq_ha_enabled and activemq_shared_storage }}"
                 type: 'bool'
     downstream:
         options:

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -486,7 +486,7 @@ argument_specs:
                 description: 'Whether systemd unit should wait for activemq port before returning'
                 default: "{{ activemq_ha_enabled and not activemq_shared_storage }}"
                 type: 'bool'
-            activemq_systemd_wait_for_port:
+            activemq_systemd_wait_for_log:
                 description: 'Whether systemd unit should wait for service to be up in logs'
                 default: "{{ activemq_ha_enabled and activemq_shared_storage }}"
                 type: 'bool'

--- a/roles/activemq/tasks/prereqs.yml
+++ b/roles/activemq/tasks/prereqs.yml
@@ -50,6 +50,7 @@
       - "{{ activemq_jvm_package }}"
       - unzip
       - iproute
+      - sed
       - procps-ng
       - initscripts
       - libaio

--- a/roles/activemq/tasks/prereqs.yml
+++ b/roles/activemq/tasks/prereqs.yml
@@ -49,6 +49,7 @@
     packages_list:
       - "{{ activemq_jvm_package }}"
       - unzip
+      - iproute
       - procps-ng
       - initscripts
       - libaio

--- a/roles/activemq/tasks/restart.yml
+++ b/roles/activemq/tasks/restart.yml
@@ -1,5 +1,6 @@
 ---
 - name: "Restart and enable instance {{ activemq.instance_name }} for {{ activemq.service_name }} service"
+  throttle: 1
   ansible.builtin.systemd:
     name: "{{ activemq.instance_name }}"
     enabled: yes

--- a/roles/activemq/tasks/start.yml
+++ b/roles/activemq/tasks/start.yml
@@ -1,5 +1,6 @@
 ---
 - name: "Start and enable instance {{ activemq.instance_name }} for {{ activemq.service_name }} service"
+  throttle: 1
   ansible.builtin.systemd:
     name: "{{ activemq.instance_name }}"
     enabled: yes

--- a/roles/activemq/templates/amq_broker.service.j2
+++ b/roles/activemq/templates/amq_broker.service.j2
@@ -21,7 +21,7 @@ TimeoutSec=600
 ExecStartPost=/usr/bin/timeout 60 sh -c 'while ! ss -H -t -l -n sport = :{{ activemq_port }} | grep -q "^LISTEN.*:{{ activemq_port }}"; do sleep 1; done'
 {% endif %}
 {% if activemq_systemd_wait_for_log %}
-ExecStartPost=/usr/bin/timeout 60 sh -c 'tail -f /var/log/{{ activemq.service_name }}/{{ activemq.instance_name }}/artemis.log | sed "/AMQ221034/ q"'
+ExecStartPost=/usr/bin/timeout 60 sh -c 'tail -f {{ activemq.instance_home }}/log/artemis.log | sed "/AMQ221034/ q"'
 {% endif %}
 
 [Install]

--- a/roles/activemq/templates/amq_broker.service.j2
+++ b/roles/activemq/templates/amq_broker.service.j2
@@ -13,12 +13,15 @@ PIDFile={{ activemq.instance_home }}/{{ activemq_service_pidfile }}
 ExecStart={{ activemq.instance_home }}/bin/artemis-service start
 ExecStop={{ activemq.instance_home }}/bin/artemis-service stop
 SuccessExitStatus = 0 143
-RestartSec = 60
+RestartSec = 120
 Restart = on-failure
 LimitNOFILE=102642
 TimeoutSec=600
 {% if activemq_systemd_wait_for_port %}
 ExecStartPost=/usr/bin/timeout 60 sh -c 'while ! ss -H -t -l -n sport = :{{ activemq_port }} | grep -q "^LISTEN.*:{{ activemq_port }}"; do sleep 1; done'
+{% endif %}
+{% if activemq_systemd_wait_for_log %}
+ExecStartPost=/usr/bin/timeout 60 sh -c 'tail -f /var/log/{{ activemq.service_name }}/{{ activemq.instance_name }}/artemis.log | sed "/AMQ221034/ q"'
 {% endif %}
 
 [Install]

--- a/roles/activemq/templates/amq_broker.service.j2
+++ b/roles/activemq/templates/amq_broker.service.j2
@@ -17,6 +17,9 @@ RestartSec = 60
 Restart = on-failure
 LimitNOFILE=102642
 TimeoutSec=600
+{% if activemq_systemd_wait_for_port %}
+ExecStartPost=/usr/bin/timeout 60 sh -c 'while ! ss -H -t -l -n sport = :{{ activemq_port }} | grep -q "^LISTEN.*:{{ activemq_port }}"; do sleep 1; done'
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The new variable, enabled by default when ha is enabled, adds a configuration to the systemd unit so that service start/restart commands return only after ports are open / console log line 

| Variable | Description | Default |
|:---------|:------------|:--------|
|`activemq_systemd_wait_for_port` | Whether systemd unit should wait for `activemq_port` before returning | `True` when activemq_ha_enabled is `True` and activemq_shared_storage is `False` |
|`activemq_systemd_wait_for_log` | Whether systemd unit should wait for service to be up in logs | `True` when activemq_ha_enabled and activemq_shared_storage are `True` |
