### PR TITLE
Add address/queue configuration

### DIFF
--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -151,6 +151,27 @@ Sample connector with TLS:
 ```
 
 
+* Addresses configuration
+
+| Variable | Description | Default |
+|:---------|:------------|:--------|
+|`activemq_addresses`| Addresses/queue configuration; list of `{ name, [anycast|multicast], and parameters }` | "Generate same configuration as `artemis create`" |
+
+Sample addresses:
+
+```
+  - name: ExpiryQueue
+    anycast:
+      - name: ExpiryQueue
+  - name: Virtual
+    anycast:
+      - name: Virtual
+        filter: 'discard="true"'
+        max_consumers: 5
+        consumers_before_dispatch: 1
+```
+
+
 * Address settings
 
 | Variable | Description | Default |

--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -155,7 +155,7 @@ Sample connector with TLS:
 
 | Variable | Description | Default |
 |:---------|:------------|:--------|
-|`activemq_addresses`| Addresses/queue configuration; list of `{ name, [anycast|multicast], and parameters }` | "Generate same configuration as `artemis create`" |
+|`activemq_addresses`| Addresses/queue configuration; list of `{ name, [anycast or multicast], and parameters }` | Generate same configuration as `artemis create` |
 
 Sample addresses:
 
@@ -166,7 +166,7 @@ Sample addresses:
   - name: Virtual
     anycast:
       - name: Virtual
-        filter: 'discard="true"'
+        filter: "discard='true'"
         max_consumers: 5
         consumers_before_dispatch: 1
 ```

--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -248,7 +248,7 @@ See _Role Variables_ below for additional TLS/SSL settings.
 |`activemq_hawtio_role`| Artemis role for hawtio console access | `amq` |
 |`activemq_management_access_default`| Management console access methods for roles in `activemq_hawtio_role` | `[ 'list*', 'get*', 'is*', 'set*', 'browse*', 'count*', '*' ]` |
 |`activemq_management_access_domains`| Management console access methods per domain for roles in `activemq_hawtio_role` | `java.lang`, `org.apache.artemis.activemq` |
-|`activemq_cors_allow_origin`| CORS allow origin setting for jolokia | `*://0.0.0.0*` |
+|`activemq_cors_allow_origin`| List of CORS allow origin setting for jolokia | `[ *://0.0.0.0* ]` |
 |`activemq_cors_strict_checking`| Whether to enforce strict checking for CORS | `True` |
 
 Sample user/role configuration with one admin, a consumer and a producer:

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -281,6 +281,3 @@ activemq_address_settings:
     auto_create_jms_topics: false
     auto_delete_queues: false
     auto_delete_addresses: false
-
-### Divert configuration
-activemq_diverts: []

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -123,7 +123,7 @@ activemq_management_access_domains:
 
 # Jolokia
 activemq_hawtio_role: amq
-activemq_cors_allow_origin: '*://0.0.0.0*'
+activemq_cors_allow_origin: [ '*://0.0.0.0*' ]
 activemq_cors_strict_checking: True
 
 # NIO option
@@ -240,6 +240,21 @@ activemq_connectors:
       supportAdvisory: false
       suppressInternalManagementObjects: false
 
+### Addresses configuration
+activemq_addresses:
+  - name: queue.in
+    anycast:
+      - name: queue.in
+  - name: queue.out
+    anycast:
+      - name: queue.out
+  - name: DLQ
+    anycast:
+      - name: DLQ
+  - name: ExpiryQueue
+    anycast:
+      - name: ExpiryQueue
+
 ### Address settings configuration
 activemq_address_settings:
   - match: activemq.management#
@@ -266,3 +281,6 @@ activemq_address_settings:
     auto_create_jms_topics: false
     auto_delete_queues: false
     auto_delete_addresses: false
+
+### Divert configuration
+activemq_diverts: []

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -395,7 +395,11 @@ argument_specs:
                 default: "Generate same configuration as `artemis create`"
                 type: "list"
             activemq_address_settings:
-                description: "Address settings configuration; list of `{ match address string and parameters }`"
+                description: "Address settings configuration; list of `{ match address string, and parameters }`"
+                default: "Generate same configuration as `artemis create`"
+                type: "list"
+            activemq_addresses:
+                description: "Address/queue configuration; list of `{ name, [anycast|multicast], and parameters }`"
                 default: "Generate same configuration as `artemis create`"
                 type: "list"
             activemq_service_override_template:

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -371,9 +371,9 @@ argument_specs:
                 default: "amq"
                 type: "str"
             activemq_cors_allow_origin:
-                description: "CORS allow origin setting for jolokia"
-                default: "*://0.0.0.0*"
-                type: "str"
+                description: "List of CORS allow origin setting for jolokia"
+                default: "[ *://0.0.0.0* ]"
+                type: "list"
             activemq_cors_strict_checking:
                 description: "Whether to enforce strict checking for CORS"
                 default: True

--- a/roles/activemq/tasks/addresses.yml
+++ b/roles/activemq/tasks/addresses.yml
@@ -1,0 +1,22 @@
+---
+- name: Create addresses string
+  ansible.builtin.set_fact:
+    addresses: "{{ addresses | default([]) + [ lookup('template', 'addresses.broker.xml.j2') ] }}"
+  loop: "{{ activemq_addresses }}"
+  loop_control:
+    loop_var: address
+    label: "{{ address.name }}"
+
+- name: Create addresses configuration in broker.xml
+  community.general.xml:
+    path: "{{ activemq.instance_home }}/etc/broker.xml"
+    xpath: /conf:configuration/core:core/core:addresses
+    input_type: xml
+    set_children: "{{ addresses }}"
+    namespaces:
+      conf: urn:activemq
+      core: urn:activemq:core
+    pretty_print: yes
+  become: yes
+  notify:
+    - restart amq_broker

--- a/roles/activemq/tasks/configure_broker.yml
+++ b/roles/activemq/tasks/configure_broker.yml
@@ -15,6 +15,7 @@
     security_settings: []
     management_access_default: []
     management_access_domains: []
+    addresses: []
     acceptors: []
     connectors: []
     address_settings: []
@@ -32,6 +33,10 @@
 - name: Configure connectors
   ansible.builtin.include_tasks: connectors.yml
   when: activemq_connectors | length > 0
+
+- name: Configure addresses
+  ansible.builtin.include_tasks: addresses.yml
+  when: activemq_addresses | length > 0
 
 - name: Configure journal
   ansible.builtin.include_tasks: journal.yml

--- a/roles/activemq/templates/addresses.broker.xml.j2
+++ b/roles/activemq/templates/addresses.broker.xml.j2
@@ -1,0 +1,30 @@
+         <address name="{{ address.name }}">
+{% if address['anycast'] is defined %}         
+            <anycast>
+{% for queue in address['anycast'] %}
+               <queue name="{{ queue.name }}" 
+                      max-consumers="{{ queue['max_consumers'] | default('-1') }}" 
+                      exclusive="{{ queue['exclusive'] | default('false') | lower }}" 
+                      consumers-before-dispatch="{{ queue['consumers_before_dispatch'] | default('0') }}"
+                      delay-before-dispatch="{{ queue['delay_before_dispatch'] | default('-1') }}">
+{% if queue['filter'] is defined %}<filter string="{{ queue['filter'] }}"/>{% endif %}
+                   <durable>{{ queue['durable'] | default('true') | lower }}</durable>
+               </queue>
+{% endfor %}               
+            </anycast>
+{% endif %}
+{% if address['multicast'] is defined %}         
+            <multicast>
+{% for queue in address['multicast'] %}
+               <queue name="{{ queue.name }}" 
+                      max-consumers="{{ queue['max_consumers'] | default('-1') }}" 
+                      exclusive="{{ queue['exclusive'] | default('false') | lower }}" 
+                      consumers-before-dispatch="{{ queue['consumers_before_dispatch'] | default('0') }}"
+                      delay-before-dispatch="{{ queue['delay_before_dispatch'] | default('-1') }}">
+{% if queue['filter'] is defined %}<filter string="{{ queue['filter'] }}"/>{% endif %}
+                   <durable>{{ queue['durable'] | default('true') | lower }}</durable>
+               </queue>
+{% endfor %}               
+            </multicast>
+{% endif %}     
+         </address>

--- a/roles/activemq/templates/jolokia-access.xml.j2
+++ b/roles/activemq/templates/jolokia-access.xml.j2
@@ -23,7 +23,9 @@ under the License.
    see: https://jolokia.org/reference/html/security.html -->
 <restrict>
     <cors>
-        <allow-origin>{{ activemq_cors_allow_origin }}</allow-origin>
+{% for origin in activemq_cors_allow_origin %}
+        <allow-origin>{{ origin }}</allow-origin>
+{% endfor %}
 {% if activemq_cors_strict_checking %}        <strict-checking/>
 {% endif %}
     </cors>


### PR DESCRIPTION
* Addresses configuration

| Variable | Description | Default |
|:---------|:------------|:--------|
|`activemq_addresses`| Addresses/queue configuration; list of `{ name, [anycast\|multicast], and parameters }` | Generate same configuration as `artemis create` |

Sample addresses:

```
  - name: ExpiryQueue
    anycast:
      - name: ExpiryQueue
  - name: Virtual
    anycast:
      - name: Virtual
        filter: 'discard="true"'
        max_consumers: 5
        consumers_before_dispatch: 1
```
