### PR TITLE
Add diverts configuration

### DIFF
--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -195,6 +195,24 @@ Sample address settings:
 ```
 
 
+* Diverts configuration
+
+| Variable | Description | Default |
+|:---------|:------------|:--------|
+|`activemq_diverts`| Diverts configuration; list of `{ name with parameters }` | `[]` |
+
+Sample divert:
+
+```
+  - name: SAMPLEDIVERT
+    address: FROMQUEUE
+    forwarding-address: TOQUEUE
+    routing-type: ANYCAST
+    filter: "msgType LIKE '%ff%'"
+    exclusive: True
+```
+
+
 * Clustering
 
 | Variable | Description | Default |

--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -206,8 +206,8 @@ Sample divert:
 ```
   - name: SAMPLEDIVERT
     address: FROMQUEUE
-    forwarding-address: TOQUEUE
-    routing-type: ANYCAST
+    forwarding_address: TOQUEUE
+    routing_type: ANYCAST
     filter: "msgType LIKE '%ff%'"
     exclusive: True
 ```

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -281,3 +281,6 @@ activemq_address_settings:
     auto_create_jms_topics: false
     auto_delete_queues: false
     auto_delete_addresses: false
+
+### Divert configuration
+activemq_diverts: []

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -402,6 +402,10 @@ argument_specs:
                 description: "Address/queue configuration; list of `{ name, [anycast|multicast], and parameters }`"
                 default: "Generate same configuration as `artemis create`"
                 type: "list"
+            activemq_diverts:
+                description: "Diverts configuration; list of `{ name with parameters }`"
+                default: "[]"
+                type: "list"
             activemq_service_override_template:
                 description: "Filename of custom systemd unit template to be deployed"
                 default: ""

--- a/roles/activemq/tasks/configure_broker.yml
+++ b/roles/activemq/tasks/configure_broker.yml
@@ -19,6 +19,7 @@
     acceptors: []
     connectors: []
     address_settings: []
+    diverts: []
 
 - name: Create user and roles
   ansible.builtin.include_tasks: user_roles.yml
@@ -44,6 +45,10 @@
 - name: Configure address settings
   ansible.builtin.include_tasks: address_settings.yml
   when: activemq_address_settings | length > 0
+
+- name: Configure diverts
+  ansible.builtin.include_tasks: diverts.yml
+  when: activemq_diverts | length > 0
 
 - name: "Configure jolokia access"
   become: yes

--- a/roles/activemq/tasks/diverts.yml
+++ b/roles/activemq/tasks/diverts.yml
@@ -1,0 +1,22 @@
+---
+- name: Create diverts configuration string
+  ansible.builtin.set_fact:
+    diverts: "{{ diverts | default([]) + [ lookup('template', 'diverts.broker.xml.j2') ] }}"
+  loop: "{{ activemq_diverts }}"
+  loop_control:
+    loop_var: divert
+    label: "{{ divert.name }}"
+
+- name: Create diverts configuration in broker.xml
+  community.general.xml:
+    path: "{{ activemq.instance_home }}/etc/broker.xml"
+    xpath: /conf:configuration/core:core/core:diverts
+    input_type: xml
+    set_children: "{{ diverts }}"
+    namespaces:
+      conf: urn:activemq
+      core: urn:activemq:core
+    pretty_print: yes
+  become: yes
+  notify:
+    - restart amq_broker

--- a/roles/activemq/templates/diverts.broker.xml.j2
+++ b/roles/activemq/templates/diverts.broker.xml.j2
@@ -1,0 +1,7 @@
+        <divert name="{{ divert.name }}">
+           <address>{{ divert.address }}</address>
+           <forwarding-address>{{ divert.forwarding_address }}</forwarding-address>
+           <routing-type>{{ divert.routing_type | default('ANYCAST') }}</routing-type>
+           {% if divert.filter is defined %}<filter string="{{ divert.filter }}"/>{% endif %}
+           <exclusive>{{ divert.exclusive | default('false') | lower }}</exclusive>
+        </divert>


### PR DESCRIPTION
* Diverts configuration

| Variable | Description | Default |
|:---------|:------------|:--------|
|`activemq_diverts`| Diverts configuration; list of `{ name with parameters }` | `[]` |

Sample divert:

```
  - name: SAMPLEDIVERT
    address: FROMQUEUE
    forwarding-address: TOQUEUE
    routing-type: ANYCAST
    filter: "msgType LIKE '%ff%'"
    exclusive: True
```
