### PR TITLE
Type for `activemq_cors_allow_origin` changed from string to list of strings

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: middleware_automation
 name: amq
-version: "1.1.2"
+version: "1.2.0"
 readme: README.md
 authors:
   - Guido Grazioli <ggraziol@redhat.com>


### PR DESCRIPTION
Change was part of #51 

| Variable | Description | Default |
|:---------|:------------|:--------|
|`activemq_cors_allow_origin`| List of CORS allow origin setting for jolokia | `[ *://0.0.0.0* ]` |

Playbooks setting activemq_cors_allow_origin on <= 1.2.0 version need to have the variable redefined as a list