### PR TITLE
Don't trigger restarts when config auto-refresh is enabled

### DIFF
--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -78,6 +78,7 @@ Role Defaults
 |`activemq_shared_storage_mounted`| Whether the systemd unit must require a mounted path (only when using shared storage) | `True` |
 |`activemq_disable_destination_autocreate`| Disable automatic creation of destination | `True` |
 |`activemq_queues`| Queue names comma separated | `queue.in,queue.out` |
+|`activemq_configuration_refresh_period`| Periodic refresh of configuration in milliseconds; can be disabled by specifying -1 | `5000` |
 
 
 * Journal configuration

--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -78,7 +78,7 @@ Role Defaults
 |`activemq_shared_storage_mounted`| Whether the systemd unit must require a mounted path (only when using shared storage) | `True` |
 |`activemq_disable_destination_autocreate`| Disable automatic creation of destination | `True` |
 |`activemq_queues`| Queue names comma separated | `queue.in,queue.out` |
-|`activemq_configuration_refresh_period`| Periodic refresh of configuration in milliseconds; can be disabled by specifying -1 | `5000` |
+|`activemq_configuration_file_refresh_period`| Periodic refresh of configuration in milliseconds; can be disabled by specifying -1 | `5000` |
 
 
 * Journal configuration

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -26,7 +26,7 @@ activemq_host: localhost
 activemq_http_port: 8161
 activemq_jolokia_url: "http://{{ activemq_host }}:{{ activemq_http_port }}/console/jolokia"
 activemq_console_url: "http://{{ activemq_host }}:{{ activemq_http_port }}/console/"
-activemq_configuration_refresh_period: 5000
+activemq_configuration_file_refresh_period: 5000
 activemq_jvm_package: java-11-openjdk-headless
 activemq_java_home:
 activemq_java_opts: "{{ [

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -26,6 +26,7 @@ activemq_host: localhost
 activemq_http_port: 8161
 activemq_jolokia_url: "http://{{ activemq_host }}:{{ activemq_http_port }}/console/jolokia"
 activemq_console_url: "http://{{ activemq_host }}:{{ activemq_http_port }}/console/"
+activemq_configuration_refresh_period: 5000
 activemq_jvm_package: java-11-openjdk-headless
 activemq_java_home:
 activemq_java_opts: "{{ [

--- a/roles/activemq/handlers/main.yml
+++ b/roles/activemq/handlers/main.yml
@@ -2,3 +2,8 @@
 - name: "Restart handler"
   ansible.builtin.include_tasks: restart.yml
   listen: "restart amq_broker"
+
+- name: "Restart handler"
+  ansible.builtin.include_tasks: restart.yml
+  when: activemq_configuration_refresh_period < 1
+  listen: "restart amq_broker with no config refresh"

--- a/roles/activemq/handlers/main.yml
+++ b/roles/activemq/handlers/main.yml
@@ -5,5 +5,5 @@
 
 - name: "Restart handler"
   ansible.builtin.include_tasks: restart.yml
-  when: activemq_configuration_refresh_period < 1
+  when: activemq_configuration_file_refresh_period < 1
   listen: "restart amq_broker with no config refresh"

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -498,7 +498,7 @@ argument_specs:
                 description: 'Whether systemd unit should wait for service to be up in logs'
                 default: "{{ activemq_ha_enabled and activemq_shared_storage }}"
                 type: 'bool'
-            activemq_configuration_refresh_period:
+            activemq_configuration_file_refresh_period:
                 description: 'Periodic refresh of configuration in milliseconds; can be disabled by specifying -1'
                 default: 5000
                 type: 'int'

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -498,6 +498,10 @@ argument_specs:
                 description: 'Whether systemd unit should wait for service to be up in logs'
                 default: "{{ activemq_ha_enabled and activemq_shared_storage }}"
                 type: 'bool'
+            activemq_configuration_refresh_period:
+                description: 'Periodic refresh of configuration in milliseconds; can be disabled by specifying -1'
+                default: 5000
+                type: 'int'
     downstream:
         options:
             amq_broker_version:

--- a/roles/activemq/tasks/address_settings.yml
+++ b/roles/activemq/tasks/address_settings.yml
@@ -19,4 +19,4 @@
     pretty_print: yes
   become: yes
   notify:
-    - restart amq_broker
+    - restart amq_broker with no config refresh

--- a/roles/activemq/tasks/addresses.yml
+++ b/roles/activemq/tasks/addresses.yml
@@ -19,4 +19,4 @@
     pretty_print: yes
   become: yes
   notify:
-    - restart amq_broker
+    - restart amq_broker with no config refresh

--- a/roles/activemq/tasks/diverts.yml
+++ b/roles/activemq/tasks/diverts.yml
@@ -31,4 +31,4 @@
     pretty_print: yes
   become: yes
   notify:
-    - restart amq_broker
+    - restart amq_broker with no config refresh

--- a/roles/activemq/tasks/journal.yml
+++ b/roles/activemq/tasks/journal.yml
@@ -27,6 +27,6 @@
     - journal_file_size
     - journal_buffer_timeout
     - journal_max_io
-    - configuration_refresh_period
+    - configuration_file_refresh_period
   loop_control:
     label: "{{ item }}"

--- a/roles/activemq/tasks/journal.yml
+++ b/roles/activemq/tasks/journal.yml
@@ -27,5 +27,6 @@
     - journal_file_size
     - journal_buffer_timeout
     - journal_max_io
+    - configuration_refresh_period
   loop_control:
     label: "{{ item }}"

--- a/roles/activemq/tasks/user_roles.yml
+++ b/roles/activemq/tasks/user_roles.yml
@@ -47,6 +47,8 @@
       core: urn:activemq:core
     pretty_print: yes
   become: yes
+  notify:
+    - restart amq_broker with no config refresh
 
 - name: "Update hawtio role"
   ansible.builtin.lineinfile:


### PR DESCRIPTION
The system will perform a periodic check on the configuration files, configured by configuration-file-refresh-period, with the default at 5000, in milliseconds. These checks can be disabled by specifying -1.

A new variable, `activemq_configuration_file_refresh_period` (same default), allows to set or disable configuration auto-refresh:

| Variable | Description | Default |
|:---------|:------------|:--------|
|`activemq_configuration_file_refresh_period`| Periodic refresh of configuration in milliseconds; can be disabled by specifying -1 | `5000` |

When auto-refresh is enabled, changes to:

* Address Settings
* Security Settings
* Diverts
* Addresses & Queues
* Bridges

should NOT trigger service restart, delegating the reload to the configuration auto-refresh feature.

