### PR TITLE
Add `activemq_data_directory` variable

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -25,6 +25,7 @@ warn_list:
   - no-log-password
   - no-empty-data-files
   - name[template]
+  - fqcn[keyword]
 
 skip_list:
   - vars_should_not_be_used

--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -85,6 +85,7 @@ Role Defaults
 
 | Variable | Description | Default |
 |:---------|:------------|:--------|
+|`activemq_data_directory`| The activemq data directory path | `data/`, or the value of `activemq_shared_storage_path` if activemq_shared_storage is set |
 |`activemq_persistence_enabled`| Whether to use the file based journal for persistence | `True` |
 |`activemq_persist_id_cache`| Whether to persist cache IDs to the journal | `True` |
 |`activemq_id_cache_size`| The duplicate detection circular cache size | `20000` |

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -64,10 +64,11 @@ activemq_id_cache_size: 20000
 # file journal configuration
 # journal type, valid values are [ ASYNCIO: libaio, MAPPED: mmap files, NIO: Plain Java Files  ]
 activemq_journal_type: ASYNCIO
-activemq_paging_directory: data/paging
-activemq_bindings_directory: data/bindings
-activemq_journal_directory: data/journal
-activemq_large_messages_directory: data/largemessages
+activemq_data_directory: "{{ activemq_shared_storage_path if activemq_shared_storage else activemq_dest + '/' + activemq_instance_name  + '/data' }}"
+activemq_paging_directory: "{{ activemq_data_directory }}/paging"
+activemq_bindings_directory: "{{ activemq_data_directory }}/bindings"
+activemq_journal_directory: "{{ activemq_data_directory }}/journal"
+activemq_large_messages_directory: "{{ activemq_data_directory }}/largemessages"
 activemq_journal_datasync: True
 activemq_journal_min_files: 2
 activemq_journal_pool_files: -1

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -502,6 +502,10 @@ argument_specs:
                 description: 'Periodic refresh of configuration in milliseconds; can be disabled by specifying -1'
                 default: 5000
                 type: 'int'
+            activemq_data_directory:
+                description: "The activemq data directory path"
+                default: "{{ activemq_shared_storage_path if activemq_shared_storage else activemq_dest + '/' + activemq_instance_name  + '/data' }}"
+                type: 'str'
     downstream:
         options:
             amq_broker_version:


### PR DESCRIPTION
Fix #56 

A new variable is introduced, so that interpolation between the default data directory path and the data directory when shared storage is enabled is possible:

|`activemq_data_directory`| The activemq data directory path | `data/`, or the value of `activemq_shared_storage_path` if activemq_shared_storage is set |
