### PR TITLE
Configuration pre-install validation against schema

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -26,6 +26,7 @@ warn_list:
   - no-empty-data-files
   - name[template]
   - fqcn[keyword]
+  - schema[meta]
 
 skip_list:
   - vars_should_not_be_used

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 *.retry
+*.xsd
 .vscode
 
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -51,9 +51,15 @@ To install all the dependencies via galaxy:
 
     ansible-galaxy collection install -r requirements.yml
 
+
 #### Python:
 
-* no extra python dependencies are currently required
+* lxml
+* jmespath
+
+To install all the dependencies:
+
+    pip install -r requirements.txt
 
 
 ## Support
@@ -62,4 +68,4 @@ The amq collection is a Beta release and for [Technical Preview](https://access.
 
 ## License
 
-[GNU General Public License v2.0](https://github.com/ansible-middleware/amq/blob/main/LICENSE)
+[Apache License 2.0](https://github.com/ansible-middleware/amq/blob/main/LICENSE)

--- a/plugins/modules/xml.py
+++ b/plugins/modules/xml.py
@@ -25,6 +25,12 @@ options:
     - This parameter is required, unless I(xmlstring) is given.
     type: path
     aliases: [ dest, file ]
+  xsd_path:
+    description:
+    - Path to the xsd schema file to perform xml validation
+    - This file must exist ahead of time.
+    - This parameter is required when I(validate) is true.
+    type: path
   xmlstring:
     description:
     - A string containing XML on which to operate.
@@ -92,6 +98,12 @@ options:
   pretty_print:
     description:
     - Pretty print XML output.
+    type: bool
+    default: false
+  validate:
+    description:
+    - Perform schema validation of the XML input.
+    - This parameter requires I(xsd_path) to be set.
     type: bool
     default: false
   content:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+lxml
+jmespath

--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -7,7 +7,8 @@ Installs and configures [Apache ActiveMQ Artemis](https://activemq.apache.org/co
 Dependencies
 ------------
 
-The role depends on the `redhat_csp_download` role of [middleware_automation.redhat_csp_download](https://github.com/ansible-middleware/redhat-csp-download) collection.
+The role depends on the `redhat_csp_download` role of [middleware_automation.redhat_csp_download](https://github.com/ansible-middleware/redhat-csp-download) collection, and [ansible.posix](https://github.com/ansible-collections/ansible.posix) collection.
+
 To install, from the collection root directory, run:
 
     ansible-galaxy collections install -r requirements.yml

--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -272,6 +272,7 @@ See _Role Variables_ below for additional TLS/SSL settings.
 |`activemq_jmx_exporter_port` | Port for prometheus JMX exporter to listen | `18080` |
 |`activemq_jmx_exporter_config_path`| JMX exporter configuration path |`{{ activemq_dest }}/{{ activemq_instance_name }}/etc/jmx_exporter.yml` |
 |`activemq_jmx_exporter_enabled`| Enable install and configuration of prometheus-jmx-exporter | `False` |
+|`activemq_jmx_exporter_package`| The rpm package name providing JMX exporter | `prometheus-jmx-exporter-openjdk11` |
 |`activemq_prometheus_enabled`| Enable install and configuration of prometheus metrics plugin | `False` |
 |`activemq_name`| Human readable service name | `Apache ActiveMQ` |
 |`activemq_config_dir`| Broker instance configuration directory | `conf` |

--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -178,23 +178,26 @@ Sample addresses:
 
 | Variable | Description | Default |
 |:---------|:------------|:--------|
-|`activemq_address_settings`| Address settings configuration; list of `{ match address string and parameters }` | "Generate same configuration as `artemis create`" |
+|`activemq_address_settings`| Address settings configuration; list of `{ match address string and parameters(dict) }` | "Generate same configuration as `artemis create`" |
 
 Sample address settings:
 
 ```
   - match: activemq.management#
-    dead_letter_address: DLQ
-    expiry_address: ExpiryQueue
-    redelivery_delay: 0
-    max_size_bytes: -1
-    message_counter_history_day_limit: 10
-    address_full_policy: PAGE
-    auto_create_queues: true
-    auto_create_addresses: true
-    auto_create_jms_queues: true
-    auto_create_jms_topics: true
+    parameters:
+      dead_letter_address: DLQ
+      expiry_address: ExpiryQueue
+      redelivery_delay: 0
+      max_size_bytes: -1
+      message_counter_history_day_limit: 10
+      address_full_policy: PAGE
+      auto_create_queues: true
+      auto_create_addresses: true
+      auto_create_jms_queues: true
+      auto_create_jms_topics: true
 ```
+
+The parameters are snake_cased variants of the artemis configuration schema elements, which are kebab-cased (ie. `dead-letter-address` -> `dead_letter_address`).
 
 
 * Diverts configuration

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -270,7 +270,7 @@ activemq_address_settings:
     auto_create_addresses: true
     auto_create_jms_queues: true
     auto_create_jms_topics: true
-  - match: #
+  - match: '#'
     dead_letter_address: DLQ
     expiry_address: ExpiryQueue
     redelivery_delay: 0

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -261,29 +261,31 @@ activemq_addresses:
 ### Address settings configuration
 activemq_address_settings:
   - match: activemq.management#
-    dead_letter_address: DLQ
-    expiry_address: ExpiryQueue
-    redelivery_delay: 0
-    max_size_bytes: -1
-    message_counter_history_day_limit: 10
-    address_full_policy: PAGE
-    auto_create_queues: true
-    auto_create_addresses: true
-    auto_create_jms_queues: true
-    auto_create_jms_topics: true
+    parameters:
+      dead_letter_address: DLQ
+      expiry_address: ExpiryQueue
+      redelivery_delay: 0
+      max_size_bytes: -1
+      message_counter_history_day_limit: 10
+      address_full_policy: PAGE
+      auto_create_queues: true
+      auto_create_addresses: true
+      auto_create_jms_queues: true
+      auto_create_jms_topics: true
   - match: '#'
-    dead_letter_address: DLQ
-    expiry_address: ExpiryQueue
-    redelivery_delay: 0
-    max_size_bytes: -1
-    message_counter_history_day_limit: 10
-    address_full_policy: PAGE
-    auto_create_queues: false
-    auto_create_addresses: false
-    auto_create_jms_queues: false
-    auto_create_jms_topics: false
-    auto_delete_queues: false
-    auto_delete_addresses: false
+    parameters:
+      dead_letter_address: DLQ
+      expiry_address: ExpiryQueue
+      redelivery_delay: 0
+      max_size_bytes: -1
+      message_counter_history_day_limit: 10
+      address_full_policy: PAGE
+      auto_create_queues: false
+      auto_create_addresses: false
+      auto_create_jms_queues: false
+      auto_create_jms_topics: false
+      auto_delete_queues: false
+      auto_delete_addresses: false
 
 ### Divert configuration
 activemq_diverts: []

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -167,6 +167,7 @@ activemq_logger_zookeeper_level: ERROR
 activemq_jmx_exporter_port: 18080
 activemq_jmx_exporter_config_path: "{{ activemq_dest }}/{{ activemq_instance_name }}/etc/jmx_exporter.yml"
 activemq_jmx_exporter_enabled: False
+activemq_jmx_exporter_package: prometheus-jmx-exporter-openjdk11
 activemq_prometheus_enabled: False
 
 ### Contoller defaults

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -395,7 +395,7 @@ argument_specs:
                 default: "Generate same configuration as `artemis create`"
                 type: "list"
             activemq_address_settings:
-                description: "Address settings configuration; list of `{ match address string, and parameters }`"
+                description: "Address settings configuration; list of `{ match address string, and parameters(dict) }`"
                 default: "Generate same configuration as `artemis create`"
                 type: "list"
             activemq_addresses:
@@ -510,6 +510,10 @@ argument_specs:
                 description: "The rpm package name providing JMX exporter"
                 default: "prometheus-jmx-exporter-openjdk11"
                 type: 'str'
+            activemq_base_package_list:
+                description: "The base list of rpm dependencies to install"
+                default: "[unzip,iproute,sed,procps-ng,initscripts,libaio,python3-lxml]"
+                type: 'list'
     downstream:
         options:
             amq_broker_version:

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -506,6 +506,10 @@ argument_specs:
                 description: "The activemq data directory path"
                 default: "{{ activemq_shared_storage_path if activemq_shared_storage else activemq_dest + '/' + activemq_instance_name  + '/data' }}"
                 type: 'str'
+            activemq_jmx_exporter_package:
+                description: "The rpm package name providing JMX exporter"
+                default: "prometheus-jmx-exporter-openjdk11"
+                type: 'str'
     downstream:
         options:
             amq_broker_version:

--- a/roles/activemq/tasks/configure_broker.yml
+++ b/roles/activemq/tasks/configure_broker.yml
@@ -10,18 +10,6 @@
   notify:
     - restart amq_broker
 
-- name: Set internal variables
-  ansible.builtin.set_fact:
-    security_settings: []
-    management_access_default: []
-    management_access_domains: []
-    addresses: []
-    acceptors: []
-    connectors: []
-    address_settings: []
-    diverts: []
-    masked_users: []
-
 - name: Create user and roles
   ansible.builtin.include_tasks: user_roles.yml
   when: activemq_users | length > 0

--- a/roles/activemq/tasks/install.yml
+++ b/roles/activemq/tasks/install.yml
@@ -54,13 +54,6 @@
   register: archive_path
 
 ## download to controller
-- name: Check local download archive path
-  ansible.builtin.stat:
-    path: "{{ activemq_local_archive_repository }}"
-  register: local_path
-  delegate_to: localhost
-  run_once: yes
-
 - name: Download AMQ archive
   ansible.builtin.get_url: # noqa risky-file-permissions delegated, uses controller host user
     url: "{{ activemq.download_url }}"

--- a/roles/activemq/tasks/main.yml
+++ b/roles/activemq/tasks/main.yml
@@ -4,6 +4,11 @@
   tags:
     - prereqs
 
+- name: Validate broker configuration
+  ansible.builtin.include_tasks: validate_config.yml
+  tags:
+    - validation
+
 - name: Include firewall config tasks
   ansible.builtin.include_tasks: firewalld.yml
   when: activemq_configure_firewalld

--- a/roles/activemq/tasks/prereqs.yml
+++ b/roles/activemq/tasks/prereqs.yml
@@ -1,19 +1,23 @@
 ---
-# - name: Validate admin console password
+# - name: Validate password strength
 #   ansible.builtin.assert:
 #     that:
 #       - activemq_admin_password | length > 12
 #     quiet: True
-#     fail_msg: "The console administrator password is empty or invalid. Please set the activemq_admin_password variable to a 16+ char long string"
-#     success_msg: "{{ 'Console administrator password OK' }}"
+#     fail_msg: "The password is empty, invalid, or too weak. Please set the variable to a 16+ char long string"
+#     success_msg: "Password OK: {{ item }}"
 
-# - name: Validate configuration
-#   ansible.builtin.assert:
-#     that:
-#       - (activemq_ha_enabled and activemq_db_enabled) or (not activemq_ha_enabled and activemq_db_enabled) or (not activemq_ha_enabled and not activemq_db_enabled)
-#     quiet: True
-#     fail_msg: "Cannot install HA setup without a backend database service. Check activemq_ha_enabled and activemq_db_enabled"
-#     success_msg: "{{ 'Configuring HA' if activemq_ha_enabled else 'Configuring standalone' }}"
+- name: Clear internal templating variables
+  ansible.builtin.set_fact:
+    security_settings: []
+    management_access_default: []
+    management_access_domains: []
+    addresses: []
+    acceptors: []
+    connectors: []
+    address_settings: []
+    diverts: []
+    masked_users: []
 
 - name: Validate credentials
   ansible.builtin.assert:
@@ -43,22 +47,33 @@
       - activemq_tls_enabled
   when: activemq_tls_mutual_authentication
 
+- name: Check local download archive path
+  ansible.builtin.stat:
+    path: "{{ activemq_local_archive_repository }}"
+  register: local_path
+  delegate_to: localhost
+  run_once: yes
+
+- name: Validate local download path
+  ansible.builtin.assert:
+    that:
+      - local_path.stat.exists
+    quiet: True
+    fail_msg: "Defined controller path for downloading resource is incorrect: {{ activemq_local_archive_repository }}"
+    success_msg: "Will download resource to controller path: {{ local_path.stat.path }}"
+
+- name: Fetch artemis configuration xsd schema for requested version
+  ansible.builtin.get_url: # noqa risky-file-permissions delegated, uses controller host user
+    url: "{{ item }}"
+    dest: "{{ local_path.stat.path }}/"
+    mode: 0640
+  delegate_to: localhost
+  run_once: yes
+  loop:
+    - "{{ activemq.config_xsd }}"
+    - https://www.w3.org/2001/03/xml.xsd
+
 - name: Ensure required packages are installed
   ansible.builtin.include_tasks: fastpackages.yml
   vars:
-    packages_list:
-      - "{{ activemq_jvm_package }}"
-      - unzip
-      - iproute
-      - sed
-      - procps-ng
-      - initscripts
-      - libaio
-      - python3-lxml
-
-- name: Ensure required packages are installed
-  ansible.builtin.dnf:
-    name: prometheus-jmx-exporter-openjdk11
-    state: present
-  when: activemq_jmx_exporter_enabled
-  become: yes
+    packages_list: "{{ activemq.package_list }}"

--- a/roles/activemq/tasks/prereqs.yml
+++ b/roles/activemq/tasks/prereqs.yml
@@ -69,6 +69,8 @@
     mode: 0640
   delegate_to: localhost
   run_once: yes
+  retries: 3
+  delay: 5
   loop:
     - "{{ activemq.config_xsd }}"
     - https://www.w3.org/2001/03/xml.xsd

--- a/roles/activemq/tasks/validate_config.yml
+++ b/roles/activemq/tasks/validate_config.yml
@@ -74,3 +74,36 @@
   become: yes
   run_once: yes
   delegate_to: localhost
+
+- name: Create diverts configuration string
+  ansible.builtin.set_fact:
+    validate_diverts: "{{ validate_diverts | default([]) + [ lookup('template', 'diverts.broker.xml.j2') ] }}"
+  loop: "{{ activemq_diverts }}"
+  loop_control:
+    loop_var: divert
+    label: "{{ divert.name }}"
+
+- name: Validate diverts
+  middleware_automation.amq.xml:
+    xsd_path: "{{ local_path.stat.path }}/artemis-configuration.xsd"
+    xmlstring: "<core xmlns=\"urn:activemq:core\"><diverts>{{ validate_diverts | join(' ') | trim }}</diverts></core>"
+    validate: yes
+    input_type: xml
+  become: yes
+  run_once: yes
+  delegate_to: localhost
+
+- name: Create security settings
+  ansible.builtin.set_fact:
+    validate_security_settings: "{{ validate_security_settings | default([]) + [ lookup('template', 'security_settings.broker.xml.j2') ] }}"
+  loop: "{{ activemq_roles }}"
+
+- name: Validate security settings
+  middleware_automation.amq.xml:
+    xsd_path: "{{ local_path.stat.path }}/artemis-configuration.xsd"
+    xmlstring: "<core xmlns=\"urn:activemq:core\"><security-settings>{{ validate_security_settings | join(' ') | trim }}</security-settings></core>"
+    validate: yes
+    input_type: xml
+  become: yes
+  run_once: yes
+  delegate_to: localhost

--- a/roles/activemq/tasks/validate_config.yml
+++ b/roles/activemq/tasks/validate_config.yml
@@ -1,0 +1,18 @@
+---
+- name: Create address settings configuration string
+  ansible.builtin.set_fact:
+    validate_address_settings: "{{ validate_address_settings | default([]) + [ lookup('template', 'address_settings.broker.xml.j2') ] }}"
+  loop: "{{ activemq_address_settings }}"
+  loop_control:
+    loop_var: address_setting
+    label: "{{ address_setting.match }}"
+
+- name: Validate address settings
+  middleware_automation.amq.xml:
+    xsd_path: "{{ local_path.stat.path }}/artemis-configuration.xsd"
+    xmlstring: "<core xmlns=\"urn:activemq:core\"><address-settings>{{ validate_address_settings | join(' ') | trim }}</address-settings></core>"
+    validate: yes
+    input_type: xml
+  become: yes
+  run_once: yes
+  delegate_to: localhost

--- a/roles/activemq/tasks/validate_config.yml
+++ b/roles/activemq/tasks/validate_config.yml
@@ -16,3 +16,43 @@
   become: yes
   run_once: yes
   delegate_to: localhost
+
+- name: Create acceptor configuration string
+  ansible.builtin.set_fact:
+    validate_acceptors: "{{ validate_acceptors | default([]) + [ lookup('template', 'acceptors.broker.xml.j2') ] }}"
+  loop: "{{ activemq_acceptors }}"
+  loop_control:
+    loop_var: acceptor
+    label: "{{ acceptor.name }}"
+  no_log: True
+
+- name: Validate acceptors
+  middleware_automation.amq.xml:
+    xsd_path: "{{ local_path.stat.path }}/artemis-configuration.xsd"
+    xmlstring: "<core xmlns=\"urn:activemq:core\"><acceptors>{{ validate_acceptors | join(' ') | trim }}</acceptors></core>"
+    validate: yes
+    input_type: xml
+  become: yes
+  run_once: yes
+  no_log: True
+  delegate_to: localhost
+
+- name: Create connector configuration string
+  ansible.builtin.set_fact:
+    validate_connectors: "{{ validate_connectors | default([]) + [ lookup('template', 'connectors.broker.xml.j2') ] }}"
+  loop: "{{ activemq_connectors }}"
+  loop_control:
+    loop_var: connector
+    label: "{{ connector.name }}"
+  no_log: True
+
+- name: Validate connectors
+  middleware_automation.amq.xml:
+    xsd_path: "{{ local_path.stat.path }}/artemis-configuration.xsd"
+    xmlstring: "<core xmlns=\"urn:activemq:core\"><connectors>{{ validate_connectors | join(' ') | trim }}</connectors></core>"
+    validate: yes
+    input_type: xml
+  become: yes
+  run_once: yes
+  no_log: True
+  delegate_to: localhost

--- a/roles/activemq/tasks/validate_config.yml
+++ b/roles/activemq/tasks/validate_config.yml
@@ -86,7 +86,7 @@
 - name: Validate diverts
   middleware_automation.amq.xml:
     xsd_path: "{{ local_path.stat.path }}/artemis-configuration.xsd"
-    xmlstring: "<core xmlns=\"urn:activemq:core\"><diverts>{{ validate_diverts | join(' ') | trim }}</diverts></core>"
+    xmlstring: "<core xmlns=\"urn:activemq:core\"><diverts>{{ validate_diverts | default([]) | join(' ') | trim }}</diverts></core>"
     validate: yes
     input_type: xml
   become: yes

--- a/roles/activemq/tasks/validate_config.yml
+++ b/roles/activemq/tasks/validate_config.yml
@@ -56,3 +56,21 @@
   run_once: yes
   no_log: True
   delegate_to: localhost
+
+- name: Create addresses string
+  ansible.builtin.set_fact:
+    validate_addresses: "{{ validate_addresses | default([]) + [ lookup('template', 'addresses.broker.xml.j2') ] }}"
+  loop: "{{ activemq_addresses }}"
+  loop_control:
+    loop_var: address
+    label: "{{ address.name }}"
+
+- name: Validate addresses
+  middleware_automation.amq.xml:
+    xsd_path: "{{ local_path.stat.path }}/artemis-configuration.xsd"
+    xmlstring: "<core xmlns=\"urn:activemq:core\"><addresses>{{ validate_addresses | join(' ') | trim }}</addresses></core>"
+    validate: yes
+    input_type: xml
+  become: yes
+  run_once: yes
+  delegate_to: localhost

--- a/roles/activemq/templates/address_settings.broker.xml.j2
+++ b/roles/activemq/templates/address_settings.broker.xml.j2
@@ -12,7 +12,6 @@
             <auto-create-dead-letter-resources>{{ address_setting.auto_create_dead_letter_resources | default('false') | lower }}</auto-create-dead-letter-resources>
             <auto-delete-queues>{{ address_setting.auto_delete_queues | default('true') | lower }}</auto-delete-queues>
             <auto-delete-addresses>{{ address_setting.auto_delete_addresses | default('true') | lower }}</auto-delete-addresses>
-            <auto-create-dead-letter-resources>{{ address_setting.auto_create_dead_letter_resources | default('false') | lower }}</auto-create-dead-letter-resources>
             <dead-letter-queue-prefix>{{ address_setting.dead_letter_prefix | default('DLQ.') }}</dead-letter-queue-prefix>
             <dead-letter-queue-suffix>{{ address_setting.dead_letter_suffix | default('') }}</dead-letter-queue-suffix>
             <auto-create-expiry-resources>{{ address_setting.auto_create_expiry_resources | default('false') | lower }}</auto-create-expiry-resources>

--- a/roles/activemq/templates/address_settings.broker.xml.j2
+++ b/roles/activemq/templates/address_settings.broker.xml.j2
@@ -1,56 +1,5 @@
          <address-setting match="{{ address_setting.match }}">
-            <dead-letter-address>{{ address_setting.dead_letter_address }}</dead-letter-address>
-            <expiry-address>{{ address_setting.expiry_address }}</expiry-address>
-            <redelivery-delay>{{ address_setting.redelivery_delay | default(0) }}</redelivery-delay>
-            <max-size-bytes>{{ address_setting.max_size_bytes | default(-1) }}</max-size-bytes>
-            <message-counter-history-day-limit>{{ address_setting.message_counter_history_day_limit | default(0) }}</message-counter-history-day-limit>
-            <address-full-policy>{{ address_setting.address_full_policy }}</address-full-policy>
-            <auto-create-queues>{{ address_setting.auto_create_queues | default('true') | lower }}</auto-create-queues>
-            <auto-create-addresses>{{ address_setting.auto_create_addresses | default('true') | lower }}</auto-create-addresses>
-            <auto-create-jms-queues>{{ address_setting.auto_create_jms_queues | default('true') | lower }}</auto-create-jms-queues>
-            <auto-create-jms-topics>{{ address_setting.auto_create_jms_topics | default('true') | lower }}</auto-create-jms-topics>
-            <auto-create-dead-letter-resources>{{ address_setting.auto_create_dead_letter_resources | default('false') | lower }}</auto-create-dead-letter-resources>
-            <auto-delete-queues>{{ address_setting.auto_delete_queues | default('true') | lower }}</auto-delete-queues>
-            <auto-delete-addresses>{{ address_setting.auto_delete_addresses | default('true') | lower }}</auto-delete-addresses>
-            <dead-letter-queue-prefix>{{ address_setting.dead_letter_prefix | default('DLQ.') }}</dead-letter-queue-prefix>
-            <dead-letter-queue-suffix>{{ address_setting.dead_letter_suffix | default('') }}</dead-letter-queue-suffix>
-            <auto-create-expiry-resources>{{ address_setting.auto_create_expiry_resources | default('false') | lower }}</auto-create-expiry-resources>
-            <expiry-queue-prefix>{{ address_setting.expiry_queue_prefix | default('EXP.') }}</expiry-queue-prefix>
-            <expiry-queue-suffix>{{ address_setting.expiry_queue_suffix | default('') }}</expiry-queue-suffix>
-            <expiry-delay>{{ address_setting.expiry_delay | default(123) }}</expiry-delay>
-            <redelivery-delay-multiplier>{{ address_setting.redelivery_delay_multiplier | default('1.0') }}</redelivery-delay-multiplier>
-            <redelivery-collision-avoidance-factor>{{ address_setting.redelivery_collision_avoidance_factor | default('0.0') }}</redelivery-collision-avoidance-factor>
-            <max-redelivery-delay>{{ address_setting.max_redelivery_delay | default(10000) }}</max-redelivery-delay>
-            <max-delivery-attempts>{{ address_setting.max_delivery_attempts | default(3) }}</max-delivery-attempts>
-            <max-size-messages>{{ address_setting.max_size_messages | default(1000) }}</max-size-messages>
-            <max-size-bytes-reject-threshold>{{ address_setting.max_size_bytes_reject_threshold | default(-1) }}</max-size-bytes-reject-threshold>
-            <page-size-bytes>{{ address_setting.page_size_bytes | default(20000) }}</page-size-bytes>
-            <default-last-value-queue>{{ address_setting.default_last_value_queue | default('false') | lower }}</default-last-value-queue>
-            <default-non-destructive>{{ address_setting.default_non_destructive | default('false') | lower }}</default-non-destructive>
-            <default-exclusive-queue>{{ address_setting.default_exclusive_queue | default('false') | lower }}</default-exclusive-queue>
-            <default-consumers-before-dispatch>{{ address_setting.default_consumers_before_dispatch | default(0) }}</default-consumers-before-dispatch>
-            <default-delay-before-dispatch>{{ address_setting.default_delay_before_dispatch | default(-1) }}</default-delay-before-dispatch>
-            <redistribution-delay>{{ address_setting.redistribution_delay | default(0) }}</redistribution-delay>
-            <send-to-dla-on-no-route>{{ address_setting.send_to_dla_on_no_route | default('false') | lower }}</send-to-dla-on-no-route>
-            <slow-consumer-threshold>{{ address_setting.slow_consumer_threshold | default(-1) }}</slow-consumer-threshold>
-            <slow-consumer-threshold-measurement-unit>{{ address_setting.slow_consumer_threshold_measurement_unit | default('MESSAGES_PER_SECOND') }}</slow-consumer-threshold-measurement-unit>
-            <slow-consumer-policy>{{ address_setting.slow_consumer_policy | default('NOTIFY') }}</slow-consumer-policy>
-            <slow-consumer-check-period>{{ address_setting.slow_consumer_check_period | default(5) }}</slow-consumer-check-period>
-            <auto-delete-created-queues>{{ address_setting.auto_delete_created_queues | default('false') | lower }}</auto-delete-created-queues>
-            <auto-delete-queues-delay>{{ address_setting.auto_create_queues_delay | default(0) }}</auto-delete-queues-delay>
-            <auto-delete-queues-message-count>{{ address_setting.auto_delete_queues_message_count | default(0) }}</auto-delete-queues-message-count>
-            <config-delete-queues>{{ address_setting.config_delete_queues | default('OFF') }}</config-delete-queues>
-            <config-delete-diverts>{{ address_setting.config_delete_diverts | default('OFF') }}</config-delete-diverts>
-            <auto-delete-addresses-delay>{{ address_setting.auto_delete_address_delay | default(0) }}</auto-delete-addresses-delay>
-            <config-delete-addresses>{{ address_setting.config_delete_address | default('OFF') }}</config-delete-addresses>
-            <management-browse-page-size>{{ address_setting.management_browse_page_size | default(200) }}</management-browse-page-size>
-            <management-message-attribute-size-limit>{{ address_setting.management_message_attribute_size_limit | default(256) }}</management-message-attribute-size-limit>
-            <default-purge-on-no-consumers>{{ address_setting.default_purge_on_no_consumers | default('false') | lower }}</default-purge-on-no-consumers>
-            <default-max-consumers>{{ address_setting.default_max_consumers | default(-1) }}</default-max-consumers>
-            <default-queue-routing-type>{{ address_setting.default_queue_routing_type | default('') }}</default-queue-routing-type>
-            <default-address-routing-type>{{ address_setting.default_address_routing_type | default('') }}</default-address-routing-type>
-            <default-ring-size>{{ address_setting.default_ring_size | default(-1) }}</default-ring-size>
-            <retroactive-message-count>{{ address_setting.retroactive_message_count | default(0) }}</retroactive-message-count>
-            <enable-metrics>{{ address_setting.enable_metrics | default('true') | lower }}</enable-metrics>
-            <enable-ingress-timestamp>{{ address_setting.enable_ingress_timestamp | default('false') | lower }}</enable-ingress-timestamp>
+{% for param in lookup('ansible.builtin.dict', address_setting.parameters, wantlist=True) %}
+            <{{ param.key | replace('_','-') }}>{{ param.value | lower }}</{{ param.key | replace('_','-') }}>
+{% endfor %}
          </address-setting>

--- a/roles/activemq/templates/address_settings.broker.xml.j2
+++ b/roles/activemq/templates/address_settings.broker.xml.j2
@@ -1,5 +1,5 @@
          <address-setting match="{{ address_setting.match }}">
 {% for param in lookup('ansible.builtin.dict', address_setting.parameters, wantlist=True) %}
-            <{{ param.key | replace('_','-') }}>{{ param.value | lower }}</{{ param.key | replace('_','-') }}>
+            <{{ param.key | replace('_','-') }}>{% if param.value is number %}{{ param.value | string | lower }}{% else %}{{ param.value }}{% endif %}</{{ param.key | replace('_','-') }}>
 {% endfor %}
          </address-setting>

--- a/roles/activemq/templates/address_settings.broker.xml.j2
+++ b/roles/activemq/templates/address_settings.broker.xml.j2
@@ -12,4 +12,46 @@
             <auto-create-dead-letter-resources>{{ address_setting.auto_create_dead_letter_resources | default('false') | lower }}</auto-create-dead-letter-resources>
             <auto-delete-queues>{{ address_setting.auto_delete_queues | default('true') | lower }}</auto-delete-queues>
             <auto-delete-addresses>{{ address_setting.auto_delete_addresses | default('true') | lower }}</auto-delete-addresses>
+            <auto-create-dead-letter-resources>{{ address_setting.auto_create_dead_letter_resources | default('false') | lower }}</auto-create-dead-letter-resources>
+            <dead-letter-queue-prefix>{{ address_setting.dead_letter_prefix | default('DLQ.') }}</dead-letter-queue-prefix>
+            <dead-letter-queue-suffix>{{ address_setting.dead_letter_suffix | default('') }}</dead-letter-queue-suffix>
+            <auto-create-expiry-resources>{{ address_setting.auto_create_expiry_resources | default('false') | lower }}</auto-create-expiry-resources>
+            <expiry-queue-prefix>{{ address_setting.expiry_queue_prefix | default('EXP.') }}</expiry-queue-prefix>
+            <expiry-queue-suffix>{{ address_setting.expiry_queue_suffix | default('') }}</expiry-queue-suffix>
+            <expiry-delay>{{ address_setting.expiry_delay | default(123) }}</expiry-delay>
+            <redelivery-delay-multiplier>{{ address_setting.redelivery_delay_multiplier | default('1.0') }}</redelivery-delay-multiplier>
+            <redelivery-collision-avoidance-factor>{{ address_setting.redelivery_collision_avoidance_factor | default('0.0') }}</redelivery-collision-avoidance-factor>
+            <max-redelivery-delay>{{ address_setting.max_redelivery_delay | default(10000) }}</max-redelivery-delay>
+            <max-delivery-attempts>{{ address_setting.max_delivery_attempts | default(3) }}</max-delivery-attempts>
+            <max-size-messages>{{ address_setting.max_size_messages | default(1000) }}</max-size-messages>
+            <max-size-bytes-reject-threshold>{{ address_setting.max_size_bytes_reject_threshold | default(-1) }}</max-size-bytes-reject-threshold>
+            <page-size-bytes>{{ address_setting.page_size_bytes | default(20000) }}</page-size-bytes>
+            <default-last-value-queue>{{ address_setting.default_last_value_queue | default('false') | lower }}</default-last-value-queue>
+            <default-non-destructive>{{ address_setting.default_non_destructive | default('false') | lower }}</default-non-destructive>
+            <default-exclusive-queue>{{ address_setting.default_exclusive_queue | default('false') | lower }}</default-exclusive-queue>
+            <default-consumers-before-dispatch>{{ address_setting.default_consumers_before_dispatch | default(0) }}</default-consumers-before-dispatch>
+            <default-delay-before-dispatch>{{ address_setting.default_delay_before_dispatch | default(-1) }}</default-delay-before-dispatch>
+            <redistribution-delay>{{ address_setting.redistribution_delay | default(0) }}</redistribution-delay>
+            <send-to-dla-on-no-route>{{ address_setting.send_to_dla_on_no_route | default('false') | lower }}</send-to-dla-on-no-route>
+            <slow-consumer-threshold>{{ address_setting.slow_consumer_threshold | default(-1) }}</slow-consumer-threshold>
+            <slow-consumer-threshold-measurement-unit>{{ address_setting.slow_consumer_threshold_measurement_unit | default('MESSAGES_PER_SECOND') }}</slow-consumer-threshold-measurement-unit>
+            <slow-consumer-policy>{{ address_setting.slow_consumer_policy | default('NOTIFY') }}</slow-consumer-policy>
+            <slow-consumer-check-period>{{ address_setting.slow_consumer_check_period | default(5) }}</slow-consumer-check-period>
+            <auto-delete-created-queues>{{ address_setting.auto_delete_created_queues | default('false') | lower }}</auto-delete-created-queues>
+            <auto-delete-queues-delay>{{ address_setting.auto_create_queues_delay | default(0) }}</auto-delete-queues-delay>
+            <auto-delete-queues-message-count>{{ address_setting.auto_delete_queues_message_count | default(0) }}</auto-delete-queues-message-count>
+            <config-delete-queues>{{ address_setting.config_delete_queues | default('OFF') }}</config-delete-queues>
+            <config-delete-diverts>{{ address_setting.config_delete_diverts | default('OFF') }}</config-delete-diverts>
+            <auto-delete-addresses-delay>{{ address_setting.auto_delete_address_delay | default(0) }}</auto-delete-addresses-delay>
+            <config-delete-addresses>{{ address_setting.config_delete_address | default('OFF') }}</config-delete-addresses>
+            <management-browse-page-size>{{ address_setting.management_browse_page_size | default(200) }}</management-browse-page-size>
+            <management-message-attribute-size-limit>{{ address_setting.management_message_attribute_size_limit | default(256) }}</management-message-attribute-size-limit>
+            <default-purge-on-no-consumers>{{ address_setting.default_purge_on_no_consumers | default('false') | lower }}</default-purge-on-no-consumers>
+            <default-max-consumers>{{ address_setting.default_max_consumers | default(-1) }}</default-max-consumers>
+            <default-queue-routing-type>{{ address_setting.default_queue_routing_type | default('') }}</default-queue-routing-type>
+            <default-address-routing-type>{{ address_setting.default_address_routing_type | default('') }}</default-address-routing-type>
+            <default-ring-size>{{ address_setting.default_ring_size | default(-1) }}</default-ring-size>
+            <retroactive-message-count>{{ address_setting.retroactive_message_count | default(0) }}</retroactive-message-count>
+            <enable-metrics>{{ address_setting.enable_metrics | default('true') | lower }}</enable-metrics>
+            <enable-ingress-timestamp>{{ address_setting.enable_ingress_timestamp | default('false') | lower }}</enable-ingress-timestamp>
          </address-setting>

--- a/roles/activemq/vars/main.yml
+++ b/roles/activemq/vars/main.yml
@@ -13,9 +13,9 @@ activemq:
   instance_name: "{{ activemq_instance_name }}"
   instance_home: "{{ activemq_dest }}/{{ activemq_instance_name }}"
   config_xsd: https://github.com/apache/activemq-artemis/raw/{{ activemq_version }}/artemis-server/src/main/resources/schema/artemis-configuration.xsd
-  package_list: "{{ base_package_list + [activemq_jvm_package] + ([activemq_jmx_exporter_package] if activemq_jmx_exporter_enabled else []) }}"
+  package_list: "{{ activemq_base_package_list + [activemq_jvm_package] + ([activemq_jmx_exporter_package] if activemq_jmx_exporter_enabled else []) }}"
 
-base_package_list:
+activemq_base_package_list:
   - unzip
   - iproute
   - sed

--- a/roles/activemq/vars/main.yml
+++ b/roles/activemq/vars/main.yml
@@ -12,4 +12,14 @@ activemq:
   service_name: "{{ activemq_service_name }}"
   instance_name: "{{ activemq_instance_name }}"
   instance_home: "{{ activemq_dest }}/{{ activemq_instance_name }}"
-  
+  config_xsd: https://github.com/apache/activemq-artemis/raw/{{ activemq_version }}/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+  package_list: "{{ base_package_list + [activemq_jvm_package] + ([activemq_jmx_exporter_package] if activemq_jmx_exporter_enabled else []) }}"
+
+base_package_list:
+  - unzip
+  - iproute
+  - sed
+  - procps-ng
+  - initscripts
+  - libaio
+  - python3-lxml


### PR DESCRIPTION
Fix #55 

Ideally `active_address_settings` items should accept a map of arbitrary activemq settings (in snake-case instead of kebab-case); given a specific activemq version, the generated configuration should be validate against the corresponding xsd, possibly in the prereq phase. An additional variable `activemq_address_settings_defaults` should control the output (or not) of passed-in parameters that are defined as default in the xml schema, in order to explicitly fix a configuration between schema updates, or alternatively accept  whatever is the default of that version.

This PR adds extra tasks before the install/configuration phase, which take care of fetching the xsd schemas for required activemq version, pre-generate the configuration, and perform a schema validation step against each of the broker.xml main elements under `<core:core>`

Additionally, it refactors how address-settings are generated, so that arbitrary configuration is accepted (and validated).

The `activemq_address_settings` variable has changed type from `list(dict)` to `list(match(str),parameters(dict)`, like follows:

```activemq_address_settings:
  - match: activemq.management#
    parameters:
      dead_letter_address: DLQ
      expiry_address: ExpiryQueue
      redelivery_delay: 0
      max_size_bytes: -1
      message_counter_history_day_limit: 10
      address_full_policy: PAGE
      auto_create_queues: true
      auto_create_addresses: true
      auto_create_jms_queues: true
      auto_create_jms_topics: true
```

