### PR TITLE
Switch middleware_automation.redhat_csp_download for middleware_automation.common

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Clone the repository, checkout the tag you want to build, or pick the main branc
 
 #### Ansible collections:
 
-* [middleware_automation.redhat_csp_download](https://github.com/ansible-middleware/redhat-csp-download)
+* [middleware_automation.common](https://github.com/ansible-middleware/common)
 * [ansible.posix](https://docs.ansible.com/ansible/latest/collections/ansible/posix/index.html)
 
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: middleware_automation
 name: amq
-version: "1.2.1"
+version: "1.3.0"
 readme: README.md
 authors:
   - Guido Grazioli <ggraziol@redhat.com>
@@ -14,7 +14,7 @@ tags:
   - messagebus
   - infrastructure
 dependencies:
-  "middleware_automation.redhat_csp_download": ">=1.2.1"
+  "middleware_automation.common": ">=1.0.0"
   "ansible.posix": ">=1.4.0"
 repository: https://github.com/ansible-middleware/amq
 documentation: https://ansible-middleware.github.io/amq

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -14,7 +14,7 @@ tags:
   - messagebus
   - infrastructure
 dependencies:
-  "middleware_automation.common": ">=1.0.0"
+  "middleware_automation.common": ">=0.0.1"
   "ansible.posix": ">=1.4.0"
 repository: https://github.com/ansible-middleware/amq
 documentation: https://ansible-middleware.github.io/amq

--- a/molecule/amq_upgrade/converge.yml
+++ b/molecule/amq_upgrade/converge.yml
@@ -8,10 +8,10 @@
       password: amqbrokerpass
       roles: [ amq ]
   collections:
-    - middleware_automation.redhat_csp_download
+    - middleware_automation.common
   tasks:
     - name: Include role for broker upgrade
       ansible.builtin.include_role:
         name: activemq
       vars:
-        activemq_version: "{{ '7.10.0' if amq_broker_enable is defined and amq_broker_enable else '2.20.0' }}"
+        activemq_version: "{{ '7.10.1' if amq_broker_enable is defined and amq_broker_enable else '2.21.0' }}"

--- a/molecule/amq_upgrade/prepare.yml
+++ b/molecule/amq_upgrade/prepare.yml
@@ -7,6 +7,6 @@
       vars:
         assets:
           - "{{ assets_server }}/amq/broker/7.9.4/amq-broker-7.9.4-bin.zip"
-          - "{{ assets_server }}/amq/broker/7.10.0/amq-broker-7.10.0-bin.zip"
+          - "{{ assets_server }}/amq/broker/7.10.1/amq-broker-7.10.1-bin.zip"
   roles:
     - activemq

--- a/molecule/amq_upgrade/requirements.yml
+++ b/molecule/amq_upgrade/requirements.yml
@@ -1,7 +1,6 @@
 ---
 collections:
-  - name: middleware_automation.redhat_csp_download
-    version: ">=1.2.1"
+  - name: middleware_automation.common
   - name: ansible.posix
   - name: community.docker
     version: ">=1.9.1"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -49,6 +49,6 @@
         filter: "msgType LIKE '%ff%'"
         exclusive: True
   collections:
-    - middleware_automation.redhat_csp_download
+    - middleware_automation.common
   roles:
     - activemq

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,7 +1,6 @@
 ---
 collections:
-  - name: middleware_automation.redhat_csp_download
-    version: ">=1.2.1"
+  - name: middleware_automation.common
   - name: community.general
   - name: ansible.posix
   - name: community.docker

--- a/molecule/static_cluster/converge.yml
+++ b/molecule/static_cluster/converge.yml
@@ -74,6 +74,6 @@
           trustStorePassword: "{{ activemq_tls_truststore_password }}"
           verifyHost: False
   collections:
-    - middleware_automation.redhat_csp_download
+    - middleware_automation.common
   roles:
     - activemq

--- a/molecule/static_cluster/requirements.yml
+++ b/molecule/static_cluster/requirements.yml
@@ -1,7 +1,6 @@
 ---
 collections:
-  - name: middleware_automation.redhat_csp_download
-    version: ">=1.2.1"
+  - name: middleware_automation.common
   - name: ansible.posix
   - name: community.docker
     version: ">=1.9.1"

--- a/playbooks/activemq.yml
+++ b/playbooks/activemq.yml
@@ -2,7 +2,7 @@
 - name: Playbook for ActiveMQ Artemis
   hosts: all
   collections:
-   - middleware_automation.redhat_csp_download
+   - middleware_automation.common
    - middleware_automation.amq
   roles:
    - activemq

--- a/playbooks/activemq_cluster.yml
+++ b/playbooks/activemq_cluster.yml
@@ -8,7 +8,7 @@
     activemq_shared_storage: true
     activemq_configure_firewalld: true
   collections:
-   - middleware_automation.redhat_csp_download
+   - middleware_automation.common
    - middleware_automation.amq
   roles:
    - activemq

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,5 +1,4 @@
 ---
 collections:
-  - name: middleware_automation.redhat_csp_download
-    version: ">=1.2.1"
+  - name: middleware_automation.common
   - name: ansible.posix

--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -7,7 +7,10 @@ Installs and configures [Apache ActiveMQ Artemis](https://activemq.apache.org/co
 Dependencies
 ------------
 
-The role depends on the `redhat_csp_download` role of [middleware_automation.redhat_csp_download](https://github.com/ansible-middleware/redhat-csp-download) collection, and [ansible.posix](https://github.com/ansible-collections/ansible.posix) collection.
+The role depends on the following collections:
+
+* [middleware_automation.common](https://github.com/ansible-middleware/common)
+* [ansible.posix](https://github.com/ansible-collections/ansible.posix)
 
 To install, from the collection root directory, run:
 
@@ -19,7 +22,7 @@ Versions
 
 | AMQ VERSION | Release Date      | Artemis Version | Notes           |
 |:------------|:------------------|:----------------|:----------------|
-| `AMQ 7.10`  | 2021.Q4           | `2.20.0`        |[Release Notes](https://access.redhat.com/documentation/en-us/red_hat_amq_broker/7.10/html/release_notes_for_red_hat_amq_broker_7.10/index)|
+| `AMQ 7.10`  | 2021.Q4           | `2.21.0`        |[Release Notes](https://access.redhat.com/documentation/en-us/red_hat_amq_broker/7.10/html/release_notes_for_red_hat_amq_broker_7.10/index)|
 | `AMQ 7.9`   | 2021.Q3           | `2.18.0`        |[Release Notes](https://access.redhat.com/documentation/en-us/red_hat_amq/2021.q3/html-single/release_notes_for_red_hat_amq_broker_7.9/index)|
 | `AMQ 7.8`   | 2020.Q4           | `2.16.0`        |[Release Notes](https://access.redhat.com/documentation/en-us/red_hat_amq/2020.q4/html-single/release_notes_for_red_hat_amq_broker_7.8/index)|
 

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -2,7 +2,7 @@ argument_specs:
     main:
         options:
             activemq_version:
-                default: "2.18.0"
+                default: "2.21.0"
                 description: "Apache Artemis version"
                 type: "str"
             activemq_archive:
@@ -520,12 +520,16 @@ argument_specs:
                 default: "7.9.4"
                 description: "Red Hat AMQ Broker version"
                 type: "str"
+            amq_broker_product_category:
+                default: "jboss.amq.broker"
+                description: "JBossNetwork API category for amq_broker"
+                type: "str"
             amq_broker_enable:
                 default: True
                 description: "Enable installation of Red Hat AMQ Broker"
                 type: "bool"
             amq_broker_offline_install:
-                default: true
+                default: False
                 description: "Perform an offline installation"
                 type: "bool"
             amq_broker_archive:
@@ -541,14 +545,6 @@ argument_specs:
             amq_broker_dest:
                 default: "/opt/amq"
                 description: "Root installation directory"
-                type: "str"
-            amq_broker_rhn_baseurl:
-                default: "https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId="
-                description: "Base RHN download URL for Red Hat AMQ Broker"
-                type: "str"
-            amq_broker_rhn_id:
-                default: "104526"
-                description: "RHN Product ID for Red Hat AMQ Broker"
                 type: "str"
             amq_broker_name:
                 description: "Human friendly name for service"

--- a/roles/activemq/meta/main.yml
+++ b/roles/activemq/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 collections:
-  - middleware_automation.redhat_csp_download
+  - middleware_automation.common
+  - ansible.posix
 
 galaxy_info:
   role_name: activemq

--- a/roles/activemq/tasks/install.yml
+++ b/roles/activemq/tasks/install.yml
@@ -68,13 +68,7 @@
     - not amq_broker_enable is defined or not amq_broker_enable
     - not activemq_offline_install
 
-- name: Perform download from RHN
-  redhat_csp_download:
-    url: "{{ activemq.download_url }}"
-    dest: "{{ local_path.stat.path }}/{{ activemq.bundle }}"
-    username: "{{ rhn_username }}"
-    password: "{{ rhn_password }}"
-  no_log: "{{ omit_rhn_output | default(true) }}"
+- name: Perform download from RHN using JBoss Network API
   delegate_to: localhost
   run_once: yes
   when:
@@ -84,6 +78,34 @@
     - amq_broker_enable is defined and amq_broker_enable
     - not activemq_offline_install
     - amq_broker_rhn_baseurl is defined and amq_broker_rhn_baseurl in activemq.download_url
+  block:
+    - name: Search Product download using JBoss Network API
+      middleware_automation.common.product_search:
+        client_id: "{{ rhn_username }}"
+        client_secret: "{{ rhn_password }}"
+        product_type: DISTRIBUTION
+        product_version: "{{ amq_broker_version }}"
+        product_category: "{{ amq_broker_product_category }}"
+      register: rhn_products
+      delegate_to: localhost
+      run_once: yes
+
+    - name: Filter install zipfile
+      ansible.builtin.set_fact:
+        rhn_filtered_product: "{{ rhn_product.results | selectattr('file_path', 'match', '.*-{{ amq_broker_version }}/amq-broker-{{ amq_broker_version }}-bin.zip') }}"
+      delegate_to: localhost
+      run_once: yes
+
+    - name: Download JWS Documentation
+      middleware_automation.common.product_download:
+        client_id: "{{ rhn_username }}"
+        client_secret: "{{ rhn_password }}"
+        product_id: "{{ (rhn_filtered_products | first).id }}"
+        dest: "{{ local_path.stat.path }}/{{ activemq.bundle }}"
+      no_log: "{{ omit_rhn_output | default(true) }}"
+      delegate_to: localhost
+      run_once: yes
+
 
 - name: Download AMQ archive from alternate location
   ansible.builtin.get_url: # noqa risky-file-permissions delegated, uses controller host user

--- a/roles/activemq/tasks/install.yml
+++ b/roles/activemq/tasks/install.yml
@@ -79,7 +79,7 @@
     - not activemq_offline_install
     - amq_broker_rhn_baseurl is defined and amq_broker_rhn_baseurl in activemq.download_url
   block:
-    - name: Search Product download using JBoss Network API
+    - name: Retrieve product download using JBoss Network API
       middleware_automation.common.product_search:
         client_id: "{{ rhn_username }}"
         client_secret: "{{ rhn_password }}"
@@ -90,13 +90,13 @@
       delegate_to: localhost
       run_once: yes
 
-    - name: Filter install zipfile
+    - name: Determine install zipfile from search results
       ansible.builtin.set_fact:
         rhn_filtered_product: "{{ rhn_product.results | selectattr('file_path', 'match', '.*-{{ amq_broker_version }}/amq-broker-{{ amq_broker_version }}-bin.zip') }}"
       delegate_to: localhost
       run_once: yes
 
-    - name: Download JWS Documentation
+    - name: Download AMQ Broker
       middleware_automation.common.product_download:
         client_id: "{{ rhn_username }}"
         client_secret: "{{ rhn_password }}"


### PR DESCRIPTION
Remove former implementation of Red Hat customer portal download and replace with new implementation provided by middleware_automation.common collection. This change only has impact on the downstream redhat.amq_broker collection.