### PR TITLE
Avoid generating duplicated security-settings match elements

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -14,6 +14,11 @@
     activemq_roles:
       - name: admin
         permissions: [ createNonDurableQueue, deleteNonDurableQueue, createDurableQueue, deleteDurableQueue, createAddress, deleteAddress, consume, browse, send, manage ]
+      - name: manager
+        permissions: [ browse, manage ]
+      - name: topicsmanager
+        match: topics.#
+        permissions: [ createNonDurableQueue, deleteNonDurableQueue, createDurableQueue, deleteDurableQueue, browse, manage ]
       - name: consumer
         match: topics.#
         permissions: [ consume, browse ]

--- a/roles/activemq/tasks/user_roles.yml
+++ b/roles/activemq/tasks/user_roles.yml
@@ -31,17 +31,26 @@
     mode: 0640
   become: yes
 
+- name: Create security settings matches
+  ansible.builtin.set_fact:
+    security_settings_matches: "{{ security_settings_matches | default({}) | combine( { match: { item.1: [ item.0.name ] }  }, recursive=True, list_merge='append' ) }}"
+  vars:
+    match: "{{ item.0.match | default('#') }}"
+  loop: "{{ activemq_roles | subelements('permissions') }}"
+  loop_control:
+    label: "{{ item.0.match | default('#') }}"
+
 - name: Create security settings
   ansible.builtin.set_fact:
-    security_settings: "{{ security_settings | default([]) + [ lookup('template', 'security_settings.broker.xml.j2') ] }}"
-  loop: "{{ activemq_roles }}"
+    security_settings: "{{ security_settings | default([]) + [ lookup('template', 'security_settings.broker.xml.j2', wantlist=True) ] }}"
+  loop: "{{ security_settings_matches | dict2items(key_name='match', value_name='permissions') }}"
 
 - name: Create messaging roles permissions
   middleware_automation.amq.xml:
     path: "{{ activemq.instance_home }}/etc/broker.xml"
     xpath: /conf:configuration/core:core/core:security-settings
     input_type: xml
-    set_children: "{{ security_settings }}"
+    set_children: "{{ security_settings | flatten }}"
     namespaces:
       conf: urn:activemq
       core: urn:activemq:core

--- a/roles/activemq/tasks/validate_config.yml
+++ b/roles/activemq/tasks/validate_config.yml
@@ -88,15 +88,24 @@
   run_once: yes
   delegate_to: localhost
 
+- name: Create security settings matches
+  ansible.builtin.set_fact:
+    validate_security_settings_matches: "{{ validate_security_settings_matches | default({}) | combine( { match: { item.1: [ item.0.name ] }  }, recursive=True, list_merge='append' ) }}"
+  vars:
+    match: "{{ item.0.match | default('#') }}"
+  loop: "{{ activemq_roles | subelements('permissions') }}"
+  loop_control:
+    label: "{{ item.0.match | default('#') }}"
+
 - name: Create security settings
   ansible.builtin.set_fact:
-    validate_security_settings: "{{ validate_security_settings | default([]) + [ lookup('template', 'security_settings.broker.xml.j2') ] }}"
-  loop: "{{ activemq_roles }}"
+    validate_security_settings: "{{ validate_security_settings | default([]) + [ lookup('template', 'security_settings.broker.xml.j2', wantlist=True) ] }}"
+  loop: "{{ validate_security_settings_matches | dict2items(key_name='match', value_name='permissions') }}"
 
 - name: Validate security settings
   middleware_automation.amq.xml:
     xsd_path: "{{ local_path.stat.path }}/artemis-configuration.xsd"
-    xmlstring: "<core xmlns=\"urn:activemq:core\"><security-settings>{{ validate_security_settings | join(' ') | trim }}</security-settings></core>"
+    xmlstring: "<core xmlns=\"urn:activemq:core\"><security-settings>{{ validate_security_settings | flatten | join(' ') | trim }}</security-settings></core>"
     validate: yes
     input_type: xml
   run_once: yes

--- a/roles/activemq/templates/security_settings.broker.xml.j2
+++ b/roles/activemq/templates/security_settings.broker.xml.j2
@@ -1,5 +1,5 @@
-    <security-setting match="{{ item.match | default('#') }}">
-{% for permission in item.permissions %}
-        <permission type="{{ permission }}" roles="{{ item.name }}"/>
+    <security-setting match="{{ item.match }}">
+{% for permission, roles in item.permissions.items()  %}
+        <permission type="{{ permission }}" roles="{{ roles | join(',') }}"/>
 {% endfor %}
-      </security-setting>
+    </security-setting>


### PR DESCRIPTION
Fix #64 
Having multiple role definitions for the same queue selector results in duplicate xml blocks with same match element