### PR TITLE
Set systemd unit to run with `activemq_system_user` user

### DIFF
--- a/roles/activemq/tasks/install.yml
+++ b/roles/activemq/tasks/install.yml
@@ -175,6 +175,8 @@
         state: link
         src: "{{ activemq_dest }}/{{ new_version_extracted.files | first }}"
         dest: "{{ activemq.home }}"
+        owner: "{{ activemq_service_user }}"
+        group: "{{ activemq_service_group }}"
       when:
         - not path_to_workdir_after_extract.stat.exists
 

--- a/roles/activemq/templates/amq_broker.service.j2
+++ b/roles/activemq/templates/amq_broker.service.j2
@@ -7,6 +7,8 @@ RequiresMountsFor={{ activemq_shared_storage_path }}
 {% endif %}
 
 [Service]
+User={{ activemq_service_user }}
+Group={{ activemq_service_group }}
 Type=forking
 EnvironmentFile=-/etc/sysconfig/{{ activemq.instance_name }}
 PIDFile={{ activemq.instance_home }}/{{ activemq_service_pidfile }}


### PR DESCRIPTION
Make the systemd unit for activemq use the `activemq_service_user` and `activemq_service_group`, instead of delegating the `artemis-service` script to do the switch

Second part fix for #75 