### PR TITLE
Default java_home path uses alternatives

### DIFF
--- a/roles/activemq/tasks/systemd.yml
+++ b/roles/activemq/tasks/systemd.yml
@@ -1,12 +1,7 @@
 ---
-- name: Determine JAVA_HOME for selected JVM RPM  # noqa blocked_modules
-  ansible.builtin.shell: |
-    set -o pipefail
-    rpm -ql {{ activemq_jvm_package }} | grep -Po '/usr/lib/jvm/.*(?=/bin/java$)'
-  args:
-    executable: /bin/bash
-  changed_when: False
-  register: rpm_java_home
+- name: Determine JAVA_HOME for selected JVM RPM
+  ansible.builtin.set_fact:
+    rpm_java_home: "/etc/alternatives/jre_{{ activemq_jvm_package | regex_search('(?<=java-)[0-9.]+') }}"
 
 - name: "Ensure systemd unit override directory exists"
   ansible.builtin.file:
@@ -26,7 +21,7 @@
     group: root
     mode: 0644
   vars:
-    activemq_rpm_java_home: "{{ rpm_java_home.stdout }}"
+    activemq_rpm_java_home: "{{ rpm_java_home }}"
   notify:
     - restart amq_broker
 


### PR DESCRIPTION
When `activemq_jvm_package` is used (default) and `activemq_java_home` is left empty (default), the JAVA_HOME path was determined inspecting the installed openjdk rpm. With this change it is now inferred from the jdk version and default alternatives paths.

Fix #81 