### PR TITLE
Allow to set arbitrary service user home_dir

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,6 +3,7 @@
   hosts: all
   gather_facts: yes
   vars:
+    activemq_service_user_home: /home/activemq
     activemq_hawtio_role: admin
     activemq_users:
       - user: amq

--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -53,6 +53,7 @@ Role Defaults
 |`activemq_service_group`| POSIX group running the service | `amq-broker` |
 |`activemq_service_pidfile`| PID file for service | `data/artemis.pid` |
 |`activemq_service_name`| systemd service unit name | `activemq` |
+|`activemq_service_user_home`| Service user home directory, defaults to artemis installation directory | `{{ activemq_dest }}/apache-artemis-{{ activemq_version }}` |
 
 
 * Common configuration

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -13,6 +13,7 @@ activemq_config_xml: amq-broker.xml
 activemq_config_override_template: ''
 activemq_service_user: amq-broker
 activemq_service_group: amq-broker
+activemq_service_user_home: "{{ activemq_dest }}/apache-artemis-{{ activemq_version }}"
 activemq_instance_name: amq-broker
 activemq_instance_username: amq-broker
 activemq_instance_password: amq-broker

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -17,6 +17,10 @@ argument_specs:
                 default: "{{ activemq_dest }}/apache-artemis-{{ activemq_version }}"
                 description: "Apache Artemis Installation path"
                 type: "str"
+            activemq_service_user_home:
+                default: "{{ activemq_dest }}/apache-artemis-{{ activemq_version }}"
+                description: "Service user home directory, defaults to artemis installation directory"
+                type: "str"
             activemq_dest:
                 default: "/opt/activemq"
                 description: "Root installation directory"

--- a/roles/activemq/tasks/install.yml
+++ b/roles/activemq/tasks/install.yml
@@ -23,7 +23,7 @@
       ansible.builtin.user:
         name: "{{ activemq_service_user }}"
         group: "{{ activemq_service_group }}"
-        home: "{{ activemq.home }}"
+        home: "{{ activemq.user_home }}"
         system: yes
         create_home: no
       register: user_mod

--- a/roles/activemq/templates/amq_broker.d.service.j2
+++ b/roles/activemq/templates/amq_broker.d.service.j2
@@ -1,2 +1,2 @@
 [Service]
-ExecStopPost=usermod --home {{ activemq.home }} {{ activemq_service_user }}
+ExecStopPost=usermod --home {{ activemq.user_home }} {{ activemq_service_user }}

--- a/roles/activemq/vars/main.yml
+++ b/roles/activemq/vars/main.yml
@@ -5,6 +5,7 @@
 ### internal variables
 activemq:
   home: "{{ activemq_installdir }}"
+  user_home: "{{ activemq_service_user_home }}"
   version: "{{ activemq_version }}"
   download_url: "{{ activemq_download_url }}"
   bundle: "{{ activemq_archive }}"


### PR DESCRIPTION
New variable:

| Variable | Description | Default |
|:---------|:------------|:--------|
|`activemq_service_user_home`| Service user home directory, defaults to artemis installation directory | `{{ activemq_dest }}/apache-artemis-{{ activemq_version }}` |

controls the path for the posix user that runs the service.

Fix #79 