### PR TITLE
Fix incorrectly defined default for `amq_broker_logger_config_template`

### DIFF
--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -580,5 +580,5 @@ argument_specs:
                 type: "str"
             amq_broker_logger_config_template:
                 description: "Template to use for logging facility configuration"
-                default: "{{ 'log4j2.properties' if activemq_version is version_compare('7.11.0', '>=') else 'logging.properties' }}"
+                default: "{{ 'log4j2.properties' if amq_broker_version is version_compare('7.11.0', '>=') else 'logging.properties' }}"
                 type: "str"

--- a/roles/activemq/vars/main.yml
+++ b/roles/activemq/vars/main.yml
@@ -25,3 +25,4 @@ activemq_base_package_list:
   - initscripts
   - libaio
   - python3-lxml
+  - tzdata-java


### PR DESCRIPTION
With `redhat.amq_broker 1.3.7` it is necessary to override default of `amq_broker_logger_config_template` to `{{ 'log4j2.properties' if amq_broker_version is version_compare('7.11.0', '>=') else 'logging.properties' }}` (or just set the filename to 'log4j2.properties' or 'logging.properties' depending on the version). The problem is in the downstream parameters defined in argument specs.

Fix #85 
Workaround for bugzilla [#2224411](https://bugzilla.redhat.com/show_bug.cgi?id=2224411)