### PR TITLE
Add parameters for `global-max-size` and `global-max-bytes`

### DIFF
--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -91,6 +91,8 @@ Role Defaults
 
 | Variable | Description | Default |
 |:---------|:------------|:--------|
+|`activemq_global_max_messages`| Number of messages before all addresses will enter into their Full Policy configured. It works in conjunction with activemq_global_max_size, being whatever value hits its maximum first. | `-1` |
+|`activemq_global_max_size` | Size (in bytes) before all addresses will enter into their Full Policy configured upon messages being produced. Supports byte notation like 'K', 'Mb', 'MiB', 'GB', etc. | `'-1'` |
 |`activemq_data_directory`| The activemq data directory path | `data/`, or the value of `activemq_shared_storage_path` if activemq_shared_storage is set |
 |`activemq_persistence_enabled`| Whether to use the file based journal for persistence | `True` |
 |`activemq_persist_id_cache`| Whether to persist cache IDs to the journal | `True` |

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 ### Version settings
-activemq_version: 2.18.0
+activemq_version: 2.21.0
 activemq_archive: "apache-artemis-{{ activemq_version }}-bin.zip"
 activemq_download_url: "https://archive.apache.org/dist/activemq/activemq-artemis/{{ activemq_version }}/{{ activemq_archive }}"  
 activemq_installdir: "{{ activemq_dest }}/apache-artemis-{{ activemq_version }}"

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -81,6 +81,9 @@ activemq_journal_device_block_size: 4096
 activemq_journal_file_size: 10M
 activemq_journal_buffer_timeout: "{{ 500000 if activemq_journal_type == 'ASYNCIO' else 3333333 }}"
 activemq_journal_max_io: "{{ 4096 if activemq_journal_type == 'ASYNCIO' else 1 }}"
+# message Full Policy configured
+activemq_global_max_messages: -1
+activemq_global_max_size: '-1'
 # database configuration for JDBC persistence
 activemq_db_enabled: False
 activemq_db_jdbc_url: 'jdbc:derby:target/derby/database-store;create=true'

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -542,6 +542,14 @@ argument_specs:
                 description: "Template to use for logging facility configuration"
                 default: "{{ 'log4j2.properties' if activemq_version is version_compare('2.27.0', '>=') else 'logging.properties' }}"
                 type: "str"
+            activemq_global_max_messages:
+                description: "Number of messages before all addresses will enter into their Full Policy configured. It works in conjunction with global-activemq_global_max_size-size, being whatever value hits its maximum first."
+                default: -1
+                type: 'int'
+            activemq_global_max_size:
+                description: "Size (in bytes) before all addresses will enter into their Full Policy configured upon messages being produced. Supports byte notation like 'K', 'Mb', 'MiB', 'GB', etc."
+                default: '-1'
+                type: "str"
     downstream:
         options:
             amq_broker_version:

--- a/roles/activemq/tasks/journal.yml
+++ b/roles/activemq/tasks/journal.yml
@@ -11,24 +11,6 @@
   become: yes
   notify:
     - restart amq_broker
-  loop:
-    - persistence_enabled
-    - persist_id_cache
-    - id_cache_size
-    - journal_type
-    - paging_directory
-    - bindings_directory
-    - journal_directory
-    - large_messages_directory
-    - journal_datasync
-    - journal_min_files
-    - journal_pool_files
-    - journal_device_block_size
-    - journal_file_size
-    - journal_buffer_timeout
-    - journal_max_io
-    - configuration_file_refresh_period
-    - global_max_messages
-    - global_max_size
+  loop: "{{ valid_core_configuration_list }}"
   loop_control:
     label: "{{ item }}"

--- a/roles/activemq/tasks/journal.yml
+++ b/roles/activemq/tasks/journal.yml
@@ -28,5 +28,7 @@
     - journal_buffer_timeout
     - journal_max_io
     - configuration_file_refresh_period
+    - global_max_messages
+    - global_max_size
   loop_control:
     label: "{{ item }}"

--- a/roles/activemq/tasks/validate_config.yml
+++ b/roles/activemq/tasks/validate_config.yml
@@ -11,6 +11,13 @@
     validate_address_settings: []
     validate_diverts: []
     validate_broker_connections: []
+    valid_core_configuration_list: []
+
+- name: Validate configuration/core and journal configuration
+  ansible.builtin.include_tasks: validate_core_config.yml
+  loop: "{{ activemq_core_configuration_list }}"
+  loop_control:
+    label: "{{ item }}"
 
 - name: Create address settings configuration string
   ansible.builtin.set_fact:

--- a/roles/activemq/tasks/validate_core_config.yml
+++ b/roles/activemq/tasks/validate_core_config.yml
@@ -1,0 +1,20 @@
+---
+- name: Add configuration element only if valid
+  delegate_to: localhost
+  block:
+    - name: Create configuration element
+      middleware_automation.common.xml:
+        xsd_path: "{{ local_path.stat.path }}/artemis-configuration.xsd"
+        xmlstring: "<core xmlns=\"urn:activemq:core\"><{{ item | replace('_','-') }}>{{ value }}</{{ item | replace('_','-') }}></core>"
+        validate: yes
+        input_type: xml
+      vars:
+        value: "{{ lookup('ansible.builtin.vars', 'activemq_' + item) | to_json | replace('\"','') }}"
+    - name: Add item to valid element list
+      ansible.builtin.set_fact:
+        valid_core_configuration_list: "{{ valid_core_configuration_list | default([]) + [ item ] }}"
+  rescue:
+    - name: Display warning
+      ansible.builtin.debug:
+        msg: "WARNING: {{ item | replace('_','-') }} is not a valid configuration element for version {{ activemq_version }} broker schema"
+      changed_when: True

--- a/roles/activemq/vars/main.yml
+++ b/roles/activemq/vars/main.yml
@@ -26,3 +26,23 @@ activemq_base_package_list:
   - libaio
   - python3-lxml
   - tzdata-java
+
+activemq_core_configuration_list:
+  - persistence_enabled
+  - persist_id_cache
+  - id_cache_size
+  - journal_type
+  - paging_directory
+  - bindings_directory
+  - journal_directory
+  - large_messages_directory
+  - journal_datasync
+  - journal_min_files
+  - journal_pool_files
+  - journal_device_block_size
+  - journal_file_size
+  - journal_buffer_timeout
+  - journal_max_io
+  - configuration_file_refresh_period
+  - global_max_messages
+  - global_max_size


### PR DESCRIPTION
New parameters allow to set broker `global-max-size` and `global-max-bytes`:

| Variable | Description | Default |
|:---------|:------------|:--------|
|`activemq_global_max_messages`| Number of messages before all addresses will enter into their Full Policy configured. It works in conjunction with activemq_global_max_size, being whatever value hits its maximum first. | `-1` |
|`activemq_global_max_size` | Size (in bytes) before all addresses will enter into their Full Policy configured upon messages being produced. Supports byte notation like 'K', 'Mb', 'MiB', 'GB', etc. | `'-1'` |

Fix #88 