### PR TITLE
Add ldap plugin configuration to JAAS login.config

### DIFF
--- a/molecule/mask_passwords/converge.yml
+++ b/molecule/mask_passwords/converge.yml
@@ -5,22 +5,23 @@
   vars:
     activemq_version: 2.29.0
     activemq_service_user_home: /home/activemq
-    activemq_hawtio_role: mathematicians
+    activemq_hawtio_role: Scientists
     activemq_password_codec: "com.ansiblemiddleware.amq.utils.PBKDF2WithHmacCodec;iterations={{ activemq_mask_password_iterations }};hashname={{ activemq_mask_password_hashname }}"
     activemq_mask_password_hashname: sha256
     activemq_mask_password_iterations: 2048
     activemq_additional_libs: [ "amq-utils-1.0.1.jar" ]
     activemq_auth_ldap_enabled: True
     activemq_auth_ldap_url: ldap://ldap.forumsys.com:389
-    activemq_auth_ldap_conn_username: cn=read-only-admin,dc=example,dc=com
+    activemq_auth_ldap_conn_username: uid=tesla,dc=example,dc=com
     activemq_auth_ldap_conn_password: password
-    activemq_auth_ldap_user_base: ou=mathematicians,dc=example,dc=com
-    activemq_auth_ldap_user_search: '(&(objectClass=inetOrgPerson)(uid={0}))'
+    activemq_auth_ldap_user_base: dc=example,dc=com
+    activemq_auth_ldap_user_search: '(uid={0})'
     activemq_auth_ldap_role_base: dc=example,dc=com
     activemq_auth_ldap_role_name: cn
-    activemq_auth_ldap_role_search: '(uniquemember=%fqdn)'
+    activemq_auth_ldap_role_search: '(uniqueMember={0})'
     activemq_auth_ldap_role_search_subtree: True
     activemq_global_max_size: 128MB
+    activemq_cors_strict_checking: False
     activemq_users:
       - user: amq
         password: amqbrokerpass
@@ -31,7 +32,7 @@
     activemq_roles:
       - name: admin
         permissions: [ createNonDurableQueue, deleteNonDurableQueue, createDurableQueue, deleteDurableQueue, createAddress, deleteAddress, consume, browse, send, manage ]
-      - name: mathematicians
+      - name: Scientists
         permissions: [ createNonDurableQueue, deleteNonDurableQueue, createDurableQueue, deleteDurableQueue, createAddress, deleteAddress, consume, browse, send, manage ]
     activemq_acceptors:
       - name: artemis

--- a/molecule/mask_passwords/converge.yml
+++ b/molecule/mask_passwords/converge.yml
@@ -5,11 +5,22 @@
   vars:
     activemq_version: 2.29.0
     activemq_service_user_home: /home/activemq
-    activemq_hawtio_role: admin
+    activemq_hawtio_role: mathematicians
     activemq_password_codec: "com.ansiblemiddleware.amq.utils.PBKDF2WithHmacCodec;iterations={{ activemq_mask_password_iterations }};hashname={{ activemq_mask_password_hashname }}"
     activemq_mask_password_hashname: sha256
     activemq_mask_password_iterations: 2048
     activemq_additional_libs: [ "amq-utils-1.0.1.jar" ]
+    activemq_auth_ldap_enabled: True
+    activemq_auth_ldap_url: ldap://ldap.forumsys.com:389
+    activemq_auth_ldap_conn_username: cn=read-only-admin,dc=example,dc=com
+    activemq_auth_ldap_conn_password: password
+    activemq_auth_ldap_user_base: ou=mathematicians,dc=example,dc=com
+    activemq_auth_ldap_user_search: '(&(objectClass=inetOrgPerson)(uid={0}))'
+    activemq_auth_ldap_role_base: dc=example,dc=com
+    activemq_auth_ldap_role_name: cn
+    activemq_auth_ldap_role_search: '(uniquemember=%fqdn)'
+    activemq_auth_ldap_role_search_subtree: True
+    activemq_global_max_size: 128MB
     activemq_users:
       - user: amq
         password: amqbrokerpass
@@ -20,17 +31,8 @@
     activemq_roles:
       - name: admin
         permissions: [ createNonDurableQueue, deleteNonDurableQueue, createDurableQueue, deleteDurableQueue, createAddress, deleteAddress, consume, browse, send, manage ]
-      - name: manager
-        permissions: [ browse, manage ]
-      - name: topicsmanager
-        match: topics.#
-        permissions: [ createNonDurableQueue, deleteNonDurableQueue, createDurableQueue, deleteDurableQueue, browse, manage ]
-      - name: consumer
-        match: topics.#
-        permissions: [ consume, browse ]
-      - name: producer
-        match: topics.#
-        permissions: [ send, browse ]
+      - name: mathematicians
+        permissions: [ createNonDurableQueue, deleteNonDurableQueue, createDurableQueue, deleteDurableQueue, createAddress, deleteAddress, consume, browse, send, manage ]
     activemq_acceptors:
       - name: artemis
         bind_address: "{{ activemq_host }}"
@@ -40,29 +42,8 @@
           tcpReceiveBufferSize: 1048576
           protocols: CORE,MQTT
           useEpoll: true
-      - name: amqp
-        bind_address: "{{ activemq_host }}"
-        bind_port: "{{ activemq_port_amqp }}"
-        parameters:
-          tcpSendBufferSize: 1048576
-          tcpReceiveBufferSize: 1048576
-          protocols: AMQP
-          useEpoll: true
-          amqpMinLargeMessageSize: 102400
-          amqpCredits: 1000
-          amqpLowCredits: 300
-          amqpDuplicateDetection: true
-    activemq_diverts:
-      - name: TESTDIVERT
-        address: queue.in
-        forwarding_address: queue.out
-        routing_type: ANYCAST
-        filter: "msgType LIKE '%ff%'"
-        exclusive: True
-  collections:
-    - middleware_automation.common
   roles:
-    - activemq
+    - middleware_automation.amq.activemq
   pre_tasks:
     - name: "Retrieve assets server from env"
       ansible.builtin.set_fact:

--- a/molecule/mask_passwords/verify.yml
+++ b/molecule/mask_passwords/verify.yml
@@ -40,11 +40,20 @@
       changed_when: False
       register: user_roles
 
-    - name: Retrieve users and roles from cli
-      ansible.builtin.debug:
-        var: user_roles
-
     - name: Verify users and roles
+      ansible.builtin.assert:
+        that:
+          - "'\"other\"()' in user_roles.stdout"
+          - "'\"amq\"(admin)' in user_roles.stdout"
+        quiet: true
+        fail_msg: "Failed to retrieve configured users"
+
+    - name: Retrieve users and roles from cli with ldap account
+      ansible.builtin.command: "/opt/amq/amq-broker/bin/artemis user list --user tesla --password password"
+      changed_when: False
+      register: user_roles
+
+    - name: Verify users and roles with ldap account
       ansible.builtin.assert:
         that:
           - "'\"other\"()' in user_roles.stdout"

--- a/molecule/mask_passwords/verify.yml
+++ b/molecule/mask_passwords/verify.yml
@@ -40,10 +40,14 @@
       changed_when: False
       register: user_roles
 
+    - name: Retrieve users and roles from cli
+      ansible.builtin.debug:
+        var: user_roles
+
     - name: Verify users and roles
       ansible.builtin.assert:
         that:
-          - "'\"other\"(producer,consumer)' in user_roles.stdout"
+          - "'\"other\"()' in user_roles.stdout"
           - "'\"amq\"(admin)' in user_roles.stdout"
         quiet: true
         fail_msg: "Failed to retrieve configured users"
@@ -70,23 +74,3 @@
       failed_when:
         - this.value is true
         - this.status is 200
-
-    - name: Check diverts element exists in broker.xml
-      community.general.xml:
-        path: "/opt/amq/amq-broker/etc/broker.xml"
-        xpath: /conf:configuration/core:core/core:diverts/core:divert
-        input_type: xml
-        state: present
-        content: attribute
-        namespaces:
-          conf: urn:activemq
-          core: urn:activemq:core
-        pretty_print: yes
-      register: diverts
-
-    - name: Check created divert configuration
-      ansible.builtin.assert:
-        that:
-          - diverts.count == 1
-        quiet: true
-        fail_msg: "Failed to retrieve generated divert"

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -68,6 +68,23 @@ activemq_mask_password: True
 activemq_mask_password_hashname: sha1
 activemq_mask_password_iterations: 1024
 
+### LDAP authn
+activemq_auth_properties_enabled: True
+activemq_auth_ldap_enabled: False
+activemq_auth_ldap_url: ldap://localhost:389
+activemq_auth_ldap_conn_username: uid=admin,ou=system
+activemq_auth_ldap_conn_password: password
+activemq_auth_ldap_conn_codec: "{{ activemq_password_codec }}"
+activemq_auth_ldap_conn_protocol: s
+activemq_auth_ldap_auth: simple
+activemq_auth_ldap_user_base: ou=Users,dc=example,dc=com
+activemq_auth_ldap_user_search: '(uid={0})'
+activemq_auth_ldap_user_search_subtree: True
+activemq_auth_ldap_role_base: ou=Groups,dc=example,dc=com
+activemq_auth_ldap_role_name: cn
+activemq_auth_ldap_role_search: '(member={0})'
+activemq_auth_ldap_role_search_subtree: False
+
 ## Additional classpath
 activemq_additional_libs: []
 

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -532,7 +532,11 @@ argument_specs:
                 type: 'str'
             activemq_base_package_list:
                 description: "The base list of rpm dependencies to install"
-                default: "[unzip,iproute,sed,procps-ng,initscripts,libaio,python3-lxml]"
+                default: "['persistence_enabled', 'persist_id_cache', 'id_cache_size', 'journal_type', 'paging_directory', 'bindings_directory', 'journal_directory', 'large_messages_directory', 'journal_datasync', 'journal_min_files', 'journal_pool_files', 'journal_device_block_size', 'journal_file_size', 'journal_buffer_timeout', 'journal_max_io', 'configuration_file_refresh_period', 'global_max_messages', 'global_max_size', 'password_codec']"
+                type: 'list'
+            activemq_core_configuration_list:
+                description: "The base list of top-level config elements to include"
+                default: "[]"
                 type: 'list'
             activemq_broker_connections:
                 description: "AMQP broker connections configuration; list of `{ name(str),uri(str),operations(list of dicts with type key in [mirror,sender,receiver,peer])) }`"
@@ -578,6 +582,66 @@ argument_specs:
                 description: "List of jars to install in activemq classpath, read from playbook files lookup paths"
                 default: []
                 type: "list"
+            activemq_auth_properties_enabled:
+                description: "Whether to enable property based JAAS config"
+                default: True
+                type: "bool"
+            activemq_auth_ldap_enabled:
+                description: "Whether to enable LDAP based JAAS config"
+                default: False
+                type: "bool"
+            activemq_auth_ldap_url:
+                description: "URL for LDAP server connection"
+                default: "ldap://localhost:389"
+                type: "str"
+            activemq_auth_ldap_conn_username:
+                description: "Bind username for LDAP server"
+                default: "uid=admin,ou=system"
+                type: "str"
+            activemq_auth_ldap_conn_password:
+                description: "Bind user password for LDAP server"
+                default: "password"
+                type: "str"
+            activemq_auth_ldap_conn_codec:
+                description: "Optional password codec class for bind user password"
+                default: "{{ activemq_password_codec }}"
+                type: "str"
+            activemq_auth_ldap_conn_protocol:
+                description: "Protocol for LDAP connection"
+                default: "s"
+                type: "str"
+            activemq_auth_ldap_auth:
+                description: "Type of LDAP server authentication"
+                default: "simple"
+                type: "str"
+            activemq_auth_ldap_user_base:
+                description: "Base for user search"
+                default: "ou=Users,dc=example,dc=com"
+                type: "str"
+            activemq_auth_ldap_user_search:
+                description: "User attribute"
+                default: "(uid={0})"
+                type: "str"
+            activemq_auth_ldap_user_search_subtree:
+                description: "Whether to enable subtree user search"
+                default: True
+                type: "bool"
+            activemq_auth_ldap_role_base:
+                description: "Base for role search"
+                default: "ou=Groups,dc=example,dc=com"
+                type: "str"
+            activemq_auth_ldap_role_name:
+                description: "Role attribute"
+                default: "cn"
+                type: "str"
+            activemq_auth_ldap_role_search:
+                description: "Role search attribute"
+                default: "(member={0})"
+                type: "str"
+            activemq_auth_ldap_role_search_subtree:
+                description: "Whether to enable subtree role search"
+                default: False
+                type: "bool"
     downstream:
         options:
             amq_broker_version:

--- a/roles/activemq/templates/login.config.j2
+++ b/roles/activemq/templates/login.config.j2
@@ -17,14 +17,38 @@
  */
 
 activemq {
-   org.apache.activemq.artemis.spi.core.security.jaas.PropertiesLoginModule required
+{% if activemq_auth_properties_enabled %}
+    org.apache.activemq.artemis.spi.core.security.jaas.PropertiesLoginModule {{ 'sufficient' if activemq_auth_ldap_enabled else 'required' }}
        debug=false
        reload=true
        org.apache.activemq.jaas.properties.user="artemis-users.properties"
        org.apache.activemq.jaas.properties.role="artemis-roles.properties"
 {% if activemq_password_codec != 'org.apache.activemq.artemis.utils.DefaultSensitiveStringCodec' %}
-       org.apache.activemq.jaas.properties.password.codec="{{ activemq_password_codec }};iterations={{ activemq_mask_password_iterations }};hashname={{ activemq_mask_password_hashname }}"
+       org.apache.activemq.jaas.properties.password.codec="{{ activemq_password_codec }}"
 {% endif %}
-       ;
+    ;
+{% endif %}
 
+{% if activemq_auth_ldap_enabled %}
+    org.apache.activemq.artemis.spi.core.security.jaas.LDAPLoginModule required
+        debug=false
+        initialContextFactory=com.sun.jndi.ldap.LdapCtxFactory
+        connectionURL="{{ activemq_auth_ldap_url }}"
+        connectionUsername="{{ activemq_auth_ldap_conn_username }}"
+        connectionPassword={{ activemq_auth_ldap_conn_password }}
+        connectionProtocol={{ activemq_auth_ldap_conn_protocol }}
+{% if activemq_password_codec != 'org.apache.activemq.artemis.utils.DefaultSensitiveStringCodec' %}
+        passwordCodec="{{ activemq_password_codec }}"
+{% endif %}
+        authentication={{ activemq_auth_ldap_auth }}
+        userBase="{{ activemq_auth_ldap_user_base }}"
+        userSearchMatching="{{ activemq_auth_ldap_user_search }}"
+        userSearchSubtree={{ activemq_auth_ldap_user_search_subtree }}
+        roleBase="{{ activemq_auth_ldap_role_base }}"
+        roleName={{ activemq_auth_ldap_role_name}}
+        roleSearchMatching="{{ activemq_auth_ldap_role_search }}"
+        roleSearchSubtree={{ activemq_auth_ldap_role_search_subtree }}
+        reload=true
+    ;
+{% endif %}
 };


### PR DESCRIPTION
The following new parameters allows to configure a secondary (sufficient) or primary (required) LDAP authentication endpoint.

| Variable | Description | Default |
|:---------|:------------|:--------|
|`activemq_auth_properties_enabled`| Whether to enable property based JAAS config | `True` |
|`activemq_auth_ldap_enabled` | Whether to enable LDAP based JAAS config" | `False` |
|`activemq_auth_ldap_url` | URL for LDAP server connection" | `ldap://localhost:389` |
|`activemq_auth_ldap_conn_username` | Bind username for LDAP server" | `uid=admin,ou=system` |
|`activemq_auth_ldap_conn_password` | Bind user password for LDAP server" | `password` |
|`activemq_auth_ldap_conn_codec` | Optional password codec class for bind user password" | `{{ activemq_password_codec }}` |
|`activemq_auth_ldap_conn_protocol` | Protocol for LDAP connection" | `s` |
|`activemq_auth_ldap_auth` | Type of LDAP server authentication" | `simple` |
|`activemq_auth_ldap_user_base` | Base for user search | `ou=Users,dc=example,dc=com` |
|`activemq_auth_ldap_user_search` | User attribute | `(uid={0})` |
|`activemq_auth_ldap_user_search_subtree` | Whether to enable subtree user search | `True` |
|`activemq_auth_ldap_role_base` | Base for role search | `ou=Groups,dc=example,dc=com` |
|`activemq_auth_ldap_role_name` | Role attribute | `cn` |
|`activemq_auth_ldap_role_search` | Role search attribute | `(member={0})` |
|`activemq_auth_ldap_role_search_subtree` | Whether to enable subtree role search | `False` |

Example:

```yaml
    activemq_hawtio_role: Scientists
    activemq_auth_ldap_enabled: True
    activemq_auth_ldap_url: ldap://ldap.forumsys.com:389
    activemq_auth_ldap_conn_username: uid=tesla,dc=example,dc=com
    activemq_auth_ldap_conn_password: password
    activemq_auth_ldap_user_base: dc=example,dc=com
    activemq_auth_ldap_user_search: '(uid={0})'
    activemq_auth_ldap_role_base: dc=example,dc=com
    activemq_auth_ldap_role_name: cn
    activemq_auth_ldap_role_search: '(uniqueMember={0})'
    activemq_auth_ldap_role_search_subtree: True
    activemq_users:
      - user: amq
        password: amqbrokerpass
        roles: [ admin ]
      - user: other
        password: amqotherpass
        roles: [ consumer, producer ]
    activemq_roles:
      - name: admin
        permissions: [ createNonDurableQueue, deleteNonDurableQueue, createDurableQueue, deleteDurableQueue, createAddress, deleteAddress, consume, browse, send, manage ]
      - name: Scientists
        permissions: [ createNonDurableQueue, deleteNonDurableQueue, createDurableQueue, deleteDurableQueue, createAddress, deleteAddress, consume, browse, send, manage ]
```

It will authenticate and authorized LDAP users in the "Scientists" group; in addition to `amq` and `other` defined in property files.
