### PR TITLE
Ignore unwanted output from `artemis mask` command

### DIFF
--- a/roles/activemq/tasks/mask_password.yml
+++ b/roles/activemq/tasks/mask_password.yml
@@ -19,7 +19,7 @@
       when: existing_user | length == 0 or hash_password != existing_user[1]
     - name: Add masked password to users list
       ansible.builtin.set_fact:
-        masked_users: "{{ masked_users | default([]) + [{ 'user': item.user, 'password': mask_pwd.stdout | regex_search('result: (.+)', '\\1') | first), 'roles': item.roles }] }}"
+        masked_users: "{{ masked_users | default([]) + [{ 'user': item.user, 'password': mask_pwd.stdout | regex_search('result: (.+)', '\\1') | first, 'roles': item.roles }] }}"
       no_log: True
       when:
         - existing_user | length == 0 or hash_password != existing_user[1]

--- a/roles/activemq/tasks/mask_password.yml
+++ b/roles/activemq/tasks/mask_password.yml
@@ -19,7 +19,7 @@
       when: existing_user | length == 0 or hash_password != existing_user[1]
     - name: Add masked password to users list
       ansible.builtin.set_fact:
-        masked_users: "{{ masked_users | default([]) + [{ 'user': item.user, 'password': mask_pwd.stdout | replace('result: ',''), 'roles': item.roles }] }}"
+        masked_users: "{{ masked_users | default([]) + [{ 'user': item.user, 'password': mask_pwd.stdout | regex_search('result: (.+)', '\\1') | first), 'roles': item.roles }] }}"
       no_log: True
       when:
         - existing_user | length == 0 or hash_password != existing_user[1]

--- a/roles/activemq/tasks/mask_password.yml
+++ b/roles/activemq/tasks/mask_password.yml
@@ -19,7 +19,7 @@
       when: existing_user | length == 0 or hash_password != existing_user[1]
     - name: Add masked password to users list
       ansible.builtin.set_fact:
-        masked_users: "{{ masked_users | default([]) + [{ 'user': item.user, 'password': mask_pwd.stdout | regex_search('result: (.+)', '\\1') | first, 'roles': item.roles }] }}"
+        masked_users: "{{ masked_users | default([]) + [{ 'user': item.user, 'password': mask_pwd.stdout | regex_search('result: (.+)', '\\1', multiline=True) | first, 'roles': item.roles }] }}"
       no_log: True
       when:
         - existing_user | length == 0 or hash_password != existing_user[1]


### PR DESCRIPTION
The command is used to create masked passwords both for the first time and to ensure idempotency. This change fixes the issue when using custom password codecs together with the prometheus metrics plugin

Fix #97 