### PR TITLE
workaround metadata change in RHN download

### DIFF
--- a/roles/activemq/tasks/fastpackages.yml
+++ b/roles/activemq/tasks/fastpackages.yml
@@ -1,19 +1,16 @@
 ---
-- name: Install package list
-  block:
-  - name: "Check if packages are already installed" # noqa command-instead-of-module this runs faster
-    ansible.builtin.command: "rpm -q {{ packages_list | join(' ') }}"
-    register: rpm_info
-    changed_when: rpm_info.failed
+- name: "Check if packages are already installed" # noqa command-instead-of-module this runs faster
+  ansible.builtin.command: "rpm -q {{ packages_list | join(' ') }}"
+  register: rpm_info
+  changed_when: False
+  failed_when: False
 
-  rescue:
-    - name: "Add missing packages to the yum install list"
-      ansible.builtin.set_fact:
-        packages_to_install: "{{ packages_to_install | default([]) + rpm_info.stdout_lines | map('regex_findall', 'package (.+) is not installed$') | flatten }}"
-      when: rpm_info.failed
+- name: "Add missing packages to the yum install list"
+  ansible.builtin.set_fact:
+    packages_to_install: "{{ packages_to_install | default([]) + rpm_info.stdout_lines | map('regex_findall', 'package (.+) is not installed$') | default([]) | flatten }}"
 
 - name: "Install packages: {{ packages_to_install }}"
-  become: yes
+  become: True
   ansible.builtin.yum:
     name: "{{ packages_to_install }}"
     state: present

--- a/roles/activemq/tasks/install.yml
+++ b/roles/activemq/tasks/install.yml
@@ -95,7 +95,7 @@
         client_id: "{{ rhn_username }}"
         client_secret: "{{ rhn_password }}"
         product_type: DISTRIBUTION
-        product_version: "{{ amq_broker_version }}"
+        product_version: "{{ amq_broker_version | regex_replace('7[.]([89])[.]', '7.0\\1.') }}"
         product_category: "{{ amq_broker_product_category }}"
       register: rhn_products
       delegate_to: localhost


### PR DESCRIPTION
Fix (workaround) #104 

The version to use is `amq_broker_version: 7.9.4` (no padding zeroes)