### PR TITLE
Improve validations for offline installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
   schedule:
     - cron: '0 6 * * *'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,3 +15,4 @@ jobs:
     with:
       fqcn: 'middleware_automation/amq'
       collection_fqcn: 'middleware_automation.amq'
+      historical_docs: 'false'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,10 @@
 name: Release collection
 on:
   workflow_dispatch:
+    inputs:
+      release_summary:
+        description: 'Optional release summary for changelogs'
+        required: false
 
 jobs:
   release:
@@ -9,6 +13,7 @@ jobs:
     with:
       collection_fqcn: 'middleware_automation.amq'
       downstream_name: 'amq_broker'
+      release_summary: "${{ github.event.inputs.release_summary }}"
     secrets:
       galaxy_token: ${{ secrets.ANSIBLE_GALAXY_API_KEY }}
       jira_webhook: ${{ secrets.JIRA_WEBHOOK_CREATE_VERSION }}

--- a/roles/activemq/tasks/acceptors.yml
+++ b/roles/activemq/tasks/acceptors.yml
@@ -6,7 +6,7 @@
   loop_control:
     loop_var: acceptor
     label: "{{ acceptor.name }}"
-  no_log: True
+  no_log: true
 
 - name: Create acceptor configuration in broker.xml
   middleware_automation.common.xml:
@@ -17,8 +17,8 @@
     namespaces:
       conf: urn:activemq
       core: urn:activemq:core
-    pretty_print: yes
-  become: True
-  no_log: True
+    pretty_print: true
+  become: true
+  no_log: true
   notify:
     - restart amq_broker

--- a/roles/activemq/tasks/address_settings.yml
+++ b/roles/activemq/tasks/address_settings.yml
@@ -16,7 +16,7 @@
     namespaces:
       conf: urn:activemq
       core: urn:activemq:core
-    pretty_print: yes
-  become: True
+    pretty_print: true
+  become: true
   notify:
     - restart amq_broker with no config refresh

--- a/roles/activemq/tasks/addresses.yml
+++ b/roles/activemq/tasks/addresses.yml
@@ -16,7 +16,7 @@
     namespaces:
       conf: urn:activemq
       core: urn:activemq:core
-    pretty_print: yes
-  become: True
+    pretty_print: true
+  become: true
   notify:
     - restart amq_broker with no config refresh

--- a/roles/activemq/tasks/broker_connections.yml
+++ b/roles/activemq/tasks/broker_connections.yml
@@ -16,8 +16,8 @@
     namespaces:
       conf: urn:activemq
       core: urn:activemq:core
-    pretty_print: yes
-  become: True
+    pretty_print: true
+  become: true
 
 - name: Create broker connections configuration in broker.xml
   middleware_automation.common.xml:
@@ -28,7 +28,7 @@
     namespaces:
       conf: urn:activemq
       core: urn:activemq:core
-    pretty_print: yes
-  become: True
+    pretty_print: true
+  become: true
   notify:
     - restart amq_broker with no config refresh

--- a/roles/activemq/tasks/configure_artemis.yml
+++ b/roles/activemq/tasks/configure_artemis.yml
@@ -15,7 +15,7 @@
       - "--message-load-balancing {{ activemq_cluster_lb_policy }}"
       - "--failover-on-shutdown"
   when: activemq_ha_enabled
-  no_log: True
+  no_log: true
 
 - name: Enable static clustering
   ansible.builtin.set_fact:
@@ -34,7 +34,7 @@
       - "--user {{ activemq_instance_username }}"
       - "--password {{ activemq_instance_password }}"
   when: not activemq_instance_anonymous
-  no_log: True
+  no_log: true
 
 - name: Disable security
   ansible.builtin.set_fact:
@@ -44,7 +44,7 @@
       - "--user {{ activemq_instance_username }}"
       - "--password {{ activemq_instance_password }}"
   when: activemq_instance_anonymous
-  no_log: True
+  no_log: true
 
 - name: Set address broker accepts connections on
   ansible.builtin.set_fact:
@@ -150,7 +150,7 @@
       - "--ssl-key {{ activemq_tls_keystore_dest }}"
       - "--ssl-key-password {{ activemq_tls_keystore_password }}"
   when: activemq_tls_enabled and activemq_tls_keystore_path and activemq_tls_keystore_password
-  no_log: True
+  no_log: true
 
 - name: Enable TLS client authentication for web UI
   ansible.builtin.set_fact:
@@ -160,7 +160,7 @@
       - "--ssl-trust-password {{ activemq_tls_truststore_password }}"
       - "--use-client-auth"
   when: activemq_tls_enabled and activemq_tls_mutual_authentication and activemq_tls_truststore_path and activemq_tls_truststore_password
-  no_log: True
+  no_log: true
 
 - name: Create final broker creation options
   ansible.builtin.set_fact:

--- a/roles/activemq/tasks/configure_broker.yml
+++ b/roles/activemq/tasks/configure_broker.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Configure AMQ broker logging"
-  become: True
+  become: true
   ansible.builtin.template:
     src: "{{ activemq_logger_config_template_path }}{{ activemq_logger_config_template }}"
     dest: "{{ activemq.instance_home }}/etc/{{ activemq_logger_config_template | basename | regex_replace('[.]j2$', '') }}"
@@ -22,8 +22,8 @@
         namespaces:
           conf: urn:activemq
           core: urn:activemq:core
-        pretty_print: yes
-      become: True
+        pretty_print: true
+      become: true
       notify:
         - restart amq_broker
     - name: "Configure ha-policy"
@@ -35,8 +35,8 @@
         namespaces:
           conf: urn:activemq
           core: urn:activemq:core
-        pretty_print: yes
-      become: True
+        pretty_print: true
+      become: true
       notify:
         - restart amq_broker
 
@@ -74,7 +74,7 @@
   when: activemq_broker_connections | length > 0
 
 - name: "Configure jolokia access"
-  become: True
+  become: true
   ansible.builtin.template:
     src: jolokia-access.xml.j2
     dest: "{{ activemq.instance_home }}/etc/jolokia-access.xml"
@@ -85,7 +85,7 @@
     - restart amq_broker
 
 - name: "Configure jaas"
-  become: True
+  become: true
   ansible.builtin.template:
     src: "{{ activemq_auth_template }}"
     dest: "{{ activemq.instance_home }}/etc/login.config"
@@ -96,22 +96,22 @@
     - restart amq_broker
 
 - name: "Configure prometheus metrics"
-  become: True
+  become: true
   when: activemq_prometheus_enabled and amq_broker_enable is defined and amq_broker_enable
   block:
     - name: Find available library path from installation
       ansible.builtin.find:
         paths: "{{ activemq.home }}/lib/"
         file_type: file
-        use_regex: yes
-        recurse: yes
+        use_regex: true
+        recurse: true
         patterns: [ 'artemis-prometheus-metrics-plugin-([0-9]+[.]){3}redhat-[0-9]+.jar$' ]
       register: prometheus_filename
     - name: Ensure lib is available to instance
       ansible.builtin.copy:
         src: "{{ prometheus_filename.files[0].path }}"
         dest: "{{ activemq.instance_home }}/lib/"
-        remote_src: yes
+        remote_src: true
         owner: "{{ activemq_service_user }}"
         group: "{{ activemq_service_group }}"
         mode: '0644'

--- a/roles/activemq/tasks/connectors.yml
+++ b/roles/activemq/tasks/connectors.yml
@@ -11,7 +11,7 @@
   loop_control:
     loop_var: connector
     label: "{{ connector.name }}"
-  no_log: True
+  no_log: true
 
 - name: Create connector configuration in broker.xml
   middleware_automation.common.xml:
@@ -22,9 +22,9 @@
     namespaces:
       conf: urn:activemq
       core: urn:activemq:core
-    pretty_print: yes
-  become: True
-  no_log: True
+    pretty_print: true
+  become: true
+  no_log: true
   notify:
     - restart amq_broker
 
@@ -46,7 +46,7 @@
         namespaces:
           conf: urn:activemq
           core: urn:activemq:core
-        pretty_print: yes
-      become: True
+        pretty_print: true
+      become: true
       notify:
         - restart amq_broker

--- a/roles/activemq/tasks/diverts.yml
+++ b/roles/activemq/tasks/diverts.yml
@@ -16,8 +16,8 @@
     namespaces:
       conf: urn:activemq
       core: urn:activemq:core
-    pretty_print: yes
-  become: True
+    pretty_print: true
+  become: true
 
 - name: Create diverts configuration in broker.xml
   middleware_automation.common.xml:
@@ -28,7 +28,7 @@
     namespaces:
       conf: urn:activemq
       core: urn:activemq:core
-    pretty_print: yes
-  become: True
+    pretty_print: true
+  become: true
   notify:
     - restart amq_broker with no config refresh

--- a/roles/activemq/tasks/fastpackages.yml
+++ b/roles/activemq/tasks/fastpackages.yml
@@ -5,13 +5,13 @@
   changed_when: False
   failed_when: False
 
-- name: "Add missing packages to the yum install list"
+- name: "Add missing packages to the install list"
   ansible.builtin.set_fact:
     packages_to_install: "{{ packages_to_install | default([]) + rpm_info.stdout_lines | map('regex_findall', 'package (.+) is not installed$') | default([]) | flatten }}"
 
 - name: "Install packages: {{ packages_to_install }}"
-  become: True
-  ansible.builtin.yum:
+  become: true
+  ansible.builtin.dnf:
     name: "{{ packages_to_install }}"
     state: present
   when: packages_to_install | default([]) | length > 0

--- a/roles/activemq/tasks/firewalld.yml
+++ b/roles/activemq/tasks/firewalld.yml
@@ -6,14 +6,14 @@
       - firewalld
 
 - name: Enable and start the firewalld service
-  become: True
+  become: true
   ansible.builtin.systemd:
     name: firewalld
     enabled: yes
     state: started
 
 - name: "Configure firewall for {{ activemq.service_name }} ports"
-  become: True
+  become: true
   ansible.posix.firewalld:
     port: "{{ item }}"
     permanent: true
@@ -28,10 +28,10 @@
     - "{{ activemq_port_stomp }}/tcp"
 
 - name: "Configure firewall for JMX exporter port"
-  become: True
+  become: true
   ansible.posix.firewalld:
     port: "{{ activemq_jmx_exporter_port }}/tcp"
     permanent: true
     state: enabled
-    immediate: yes
+    immediate: true
   when: activemq_jmx_exporter_enabled

--- a/roles/activemq/tasks/install.yml
+++ b/roles/activemq/tasks/install.yml
@@ -19,7 +19,7 @@
 - name: "Create service user"
   block:
     - name: "Create {{ activemq.service_name }} service user"
-      become: True
+      become: true
       ansible.builtin.user:
         name: "{{ activemq_service_user }}"
         group: "{{ activemq_service_group }}"
@@ -59,7 +59,7 @@
     archive: "{{ activemq_dest }}/{{ activemq.bundle }}"
 
 - name: Check download archive path
-  become: True
+  become: true
   ansible.builtin.stat:
     path: "{{ archive }}"
   register: archive_path

--- a/roles/activemq/tasks/mask_password.yml
+++ b/roles/activemq/tasks/mask_password.yml
@@ -8,26 +8,26 @@
       ansible.builtin.set_fact:
         hash_password: "{{ item.password | middleware_automation.amq.pbkdf2_hmac(hashname=activemq_mask_password_hashname, iterations=activemq_mask_password_iterations, hexsalt=existing_user[0]) }}"
       when: existing_user | length > 0
-      no_log: True
+      no_log: true
     - name: Get masked password for user
       ansible.builtin.command: "{{ activemq.instance_home }}/bin/artemis mask --hash {{ '--password-codec' if activemq_password_codec != 'org.apache.activemq.artemis.utils.DefaultSensitiveStringCodec' else '' }} -- '{{ item.password }}'"
-      become: True
+      become: true
       become_user: "{{ activemq_service_user }}"
       register: mask_pwd
       changed_when: False
-      no_log: True
+      no_log: true
       when: existing_user | length == 0 or hash_password != existing_user[1]
     - name: Add masked password to users list
       ansible.builtin.set_fact:
         masked_users: "{{ masked_users | default([]) + [{ 'user': item.user, 'password': mask_pwd.stdout | regex_search('result: (.+)', '\\1', multiline=True) | first, 'roles': item.roles }] }}"
-      no_log: True
+      no_log: true
       when:
         - existing_user | length == 0 or hash_password != existing_user[1]
         - item.password is defined and item.password | length > 0
     - name: Add existing user to users list
       ansible.builtin.set_fact:
         masked_users: "{{ masked_users | default([]) + [{ 'user': item.user, 'password': activemq_mask_password_iterations | string + ':' + existing_user[0] + ':' + existing_user[1], 'roles': item.roles }] }}"
-      no_log: True
+      no_log: true
       when:
         - existing_user | length > 0
         - hash_password == existing_user[1]

--- a/roles/activemq/tasks/prereqs.yml
+++ b/roles/activemq/tasks/prereqs.yml
@@ -15,13 +15,14 @@
 
 - name: Validate credentials
   ansible.builtin.assert:
-    that:
-      - (rhn_username is defined and amq_broker_enable is defined and amq_broker_enable) or \
-        amq_broker_enable is not defined or not amq_broker_enable or activemq_offline_install
-      - (rhn_password is defined and amq_broker_enable is defined and amq_broker_enable) or \
-        amq_broker_enable is not defined or not amq_broker_enable or activemq_offline_install
+    that: >
+      ((rhn_username is defined and amq_broker_enable is defined and amq_broker_enable) or
+        amq_broker_enable is not defined or not amq_broker_enable or activemq_offline_install) and
+      ((rhn_password is defined and amq_broker_enable is defined and amq_broker_enable) or
+        amq_broker_enable is not defined or not amq_broker_enable or activemq_offline_install)
     quiet: true
-    fail_msg: "Cannot install Red Hat AMQ Broker without RHN credentials. Check rhn_username and rhn_password are defined or use offline installation"
+    fail_msg: >
+      Cannot install Red Hat AMQ Broker without RHN credentials. Check rhn_username and rhn_password are defined or use offline installation
     success_msg: "{{ 'Installing ' + activemq.service_name }}"
 
 - name: Validate TLS config

--- a/roles/activemq/tasks/prereqs.yml
+++ b/roles/activemq/tasks/prereqs.yml
@@ -1,12 +1,4 @@
 ---
-# - name: Validate password strength
-#   ansible.builtin.assert:
-#     that:
-#       - activemq_admin_password | length > 12
-#     quiet: True
-#     fail_msg: "The password is empty, invalid, or too weak. Please set the variable to a 16+ char long string"
-#     success_msg: "Password OK: {{ item }}"
-
 - name: Clear internal templating variables
   ansible.builtin.set_fact:
     security_settings: []
@@ -24,8 +16,10 @@
 - name: Validate credentials
   ansible.builtin.assert:
     that:
-      - (rhn_username is defined and amq_broker_enable is defined and amq_broker_enable) or amq_broker_enable is not defined or not amq_broker_enable or activemq_offline_install
-      - (rhn_password is defined and amq_broker_enable is defined and amq_broker_enable) or amq_broker_enable is not defined or not amq_broker_enable or activemq_offline_install
+      - (rhn_username is defined and amq_broker_enable is defined and amq_broker_enable) or \
+        amq_broker_enable is not defined or not amq_broker_enable or activemq_offline_install
+      - (rhn_password is defined and amq_broker_enable is defined and amq_broker_enable) or \
+        amq_broker_enable is not defined or not amq_broker_enable or activemq_offline_install
     quiet: true
     fail_msg: "Cannot install Red Hat AMQ Broker without RHN credentials. Check rhn_username and rhn_password are defined or use offline installation"
     success_msg: "{{ 'Installing ' + activemq.service_name }}"
@@ -55,14 +49,39 @@
   register: local_path
   delegate_to: localhost
   run_once: true
+  become: false
 
 - name: Validate local download path
   ansible.builtin.assert:
     that:
       - local_path.stat.exists
+      - local_path.stat.readable
+      - activemq_offline_install or local_path.stat.writeable
     quiet: true
     fail_msg: "Defined controller path for downloading resource is incorrect: {{ activemq_local_archive_repository }}"
     success_msg: "Will download resource to controller path: {{ local_path.stat.path }}"
+  delegate_to: localhost
+  run_once: true
+
+- name: Check downloaded archive if offline
+  ansible.builtin.stat:
+    path: "{{ local_path.stat.path }}/{{ activemq.bundle }}"
+  when: activemq_offline_install
+  register: local_archive_path_check
+  delegate_to: localhost
+  run_once: true
+
+- name: Validate local downloaded archive if offline
+  ansible.builtin.assert:
+    that:
+      - local_archive_path_check.stat.exists
+      - local_archive_path_check.stat.readable
+    quiet: true
+    fail_msg: "Configured for offline install but install archive not found at: {{ local_archive_path_check.stat.path }}"
+    success_msg: "Will install offline with expected archive: {{ local_archive_path_check.stat.path }}"
+  when: activemq_offline_install
+  delegate_to: localhost
+  run_once: true
 
 - name: Validate local custom template
   ansible.builtin.assert:

--- a/roles/activemq/tasks/start.yml
+++ b/roles/activemq/tasks/start.yml
@@ -3,6 +3,6 @@
   throttle: 1
   ansible.builtin.systemd:
     name: "{{ activemq.instance_name }}"
-    enabled: yes
+    enabled: true
     state: started
   become: True

--- a/roles/activemq/tasks/upgrade.yml
+++ b/roles/activemq/tasks/upgrade.yml
@@ -4,7 +4,7 @@
     path: "{{ activemq.instance_home }}/etc/artemis.profile"
     regexp: '^ARTEMIS_HOME=.*'
     line: "ARTEMIS_HOME='{{ activemq.home }}'"
-  become: True
+  become: true
   register: broker_updated
   notify:
     - restart amq_broker
@@ -17,18 +17,18 @@
     namespaces:
       xs: http://www.w3.org/2001/XMLSchema
   register: activemq_xsd
-  become: True
+  become: true
 
 - name: "Ensure bootstrap xsd namespace {{ activemq_xsd.matches[0]['{http://www.w3.org/2001/XMLSchema}schema'].targetNamespace }} is correct for instance {{ activemq.instance_name }}"
   ansible.builtin.lineinfile:
     path: "{{ activemq.instance_home }}/etc/bootstrap.xml"
     regexp: '<broker xmlns=".*">'
     line: "<broker xmlns=\"{{ activemq_xsd.matches[0]['{http://www.w3.org/2001/XMLSchema}schema'].targetNamespace }}\">"
-  become: True
+  become: true
 
 - name: "Ensure mgmt context xsd namespace {{ activemq_xsd.matches[0]['{http://www.w3.org/2001/XMLSchema}schema'].targetNamespace }} is correct for instance {{ activemq.instance_name }}"
   ansible.builtin.lineinfile:
     path: "{{ activemq.instance_home }}/etc/management.xml"
     regexp: '<management-context xmlns=".*">'
     line: "<management-context xmlns=\"{{ activemq_xsd.matches[0]['{http://www.w3.org/2001/XMLSchema}schema'].targetNamespace }}\">"
-  become: True
+  become: true

--- a/roles/activemq/tasks/validate_config.yml
+++ b/roles/activemq/tasks/validate_config.yml
@@ -112,7 +112,7 @@
     validate: true
     input_type: xml
   when: activemq_diverts | length > 0
-  run_once: True
+  run_once: true
   delegate_to: localhost
 
 - name: Create amqp broker connections configuration string
@@ -154,5 +154,5 @@
     xmlstring: "<core xmlns=\"urn:activemq:core\"><security-settings>{{ validate_security_settings | flatten | join(' ') | trim }}</security-settings></core>"
     validate: true
     input_type: xml
-  run_once: True
+  run_once: true
   delegate_to: localhost


### PR DESCRIPTION
General improvements to validation of controller download directory (`activemq_local_archive_repository`) and downloaded install archive for both cases of `activemq_offline_install`.

Fix #123 