### PR TITLE
set JAVA_HOME when executing artemis command to create broker instance.

### DIFF
--- a/roles/activemq/tasks/systemd.yml
+++ b/roles/activemq/tasks/systemd.yml
@@ -56,6 +56,8 @@
   ansible.builtin.command:
     cmd: "{{ activemq.home }}/bin/artemis create {{ activemq.instance_home }} {{ activemq_options }}"
     creates: "{{ activemq.instance_home }}/bin/artemis-service"
+  environment: 
+    - JAVA_HOME: "{{ rpm_java_home }}"
   become: true
   become_user: "{{ activemq_service_user }}"
   register: broker_created


### PR DESCRIPTION
see https://issues.redhat.com/browse/AMWSUP-21

Given a VM where Java 8 is still the installed version of Java

When the `amq_broker` role is executed, the deployment fails. The task to run the `artemis create` command to create the broker instance fails because `artemis` was compiled with a more recent version of Java than Java8 can execute.

Solution: set the `JAVA_HOME` envvar to match `amq_broker_jvm_package`.