### PR TITLE
Update default jdk11 to jdk17

### DIFF
--- a/molecule/custom_xml/converge.yml
+++ b/molecule/custom_xml/converge.yml
@@ -4,5 +4,6 @@
   gather_facts: yes
   vars:
     activemq_config_override_template: 'broker.xml.j2'
+    activemq_jvm_package: java-11-openjdk-headless
   roles:
     - middleware_automation.amq.activemq

--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -73,7 +73,7 @@ Role Defaults
 |`activemq_http_port`| Service http port serving console and REST api | `8161` |
 |`activemq_jolokia_url`| URL for jolokia REST api | `http://{{ activemq_host }}:{{ activemq_http_port }}/console/jolokia` |
 |`activemq_console_url`| URL for console service | `http://{{ activemq_host }}:{{ activemq_http_port }}/console/` |
-|`activemq_jvm_package`| RPM package to install for the service | `java-11-openjdk-headless` |
+|`activemq_jvm_package`| RPM package to install for the service | `java-17-openjdk-headless` |
 |`activemq_java_opts`| Additional JVM options for the service | `-Xms512M -Xmx2G [...]` |
 |`activemq_port`| Main port for the broker instance | `61616` |
 |`activemq_port_hornetq`| hornetq port for the broker instance | `5445` |

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -29,7 +29,7 @@ activemq_http_port: 8161
 activemq_jolokia_url: "http://{{ activemq_host }}:{{ activemq_http_port }}/console/jolokia"
 activemq_console_url: "http://{{ activemq_host }}:{{ activemq_http_port }}/console/"
 activemq_configuration_file_refresh_period: 5000
-activemq_jvm_package: java-11-openjdk-headless
+activemq_jvm_package: java-17-openjdk-headless
 activemq_java_home:
 activemq_java_opts: "{{ [
    activemq_java_opts_mem,

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -114,7 +114,7 @@ argument_specs:
                 type: "str"
             activemq_jvm_package:
                 # line 35 of defaults/main.yml
-                default: "java-11-openjdk-headless"
+                default: "java-17-openjdk-headless"
                 description: "RPM package to install for the service"
                 type: "str"
             activemq_java_home:


### PR DESCRIPTION
Default value for the parameter `activemq_jvm_package` updated from `java-11-openjdk-headless` to `java-17-openjdk-headless`. 

If for any reason you need to continue using jdk11, and the parameter was not already present in the playbook/inventory, you now need to set it explicitly.

Closes #129 