### PR TITLE
Fix `broker-connections` templating error, add missing parameters

### DIFF
--- a/molecule/static_cluster/converge.yml
+++ b/molecule/static_cluster/converge.yml
@@ -22,7 +22,7 @@
         parameters:
           tcpSendBufferSize: 1048576
           tcpReceiveBufferSize: 1048576
-          protocols: CORE
+          protocols: CORE,AMQP
           useEpoll: true
           sslEnabled: true
           keyStorePath: "{{ activemq_tls_keystore_dest }}"
@@ -59,15 +59,24 @@
           trustStorePath: "{{ activemq_tls_truststore_dest }}"
           trustStorePassword: "{{ activemq_tls_truststore_password }}"
           verifyHost: False
-    activemq_broker_connections:
-      - uri: vm://0
-        name: brokerA-2-brokerB
-        operations:
-          - type: sender
-            parameters:
-              address_match: 'b.#'
-          - type: receiver
-            parameters:
-              address_match: 'a.#'
+    activemq_addresses:
+      - name: queue.in
+        anycast:
+          - name: queue.in
+      - name: queue.out
+        anycast:
+          - name: queue.out
+      - name: DLQ
+        anycast:
+          - name: DLQ
+      - name: ExpiryQueue
+        anycast:
+          - name: ExpiryQueue
+      - name: a.test
+        anycast:
+          - name: a.test
+      - name: b.test
+        anycast:
+          - name: b.test
   roles:
     - middleware_automation.amq.activemq

--- a/molecule/static_cluster/converge.yml
+++ b/molecule/static_cluster/converge.yml
@@ -59,5 +59,15 @@
           trustStorePath: "{{ activemq_tls_truststore_dest }}"
           trustStorePassword: "{{ activemq_tls_truststore_password }}"
           verifyHost: False
+    activemq_broker_connections:
+      - uri: vm://0
+        name: brokerA-2-brokerB
+        operations:
+          - type: sender
+            parameters:
+              address_match: 'b.#'
+          - type: receiver
+            parameters:
+              address_match: 'a.#'
   roles:
     - middleware_automation.amq.activemq

--- a/molecule/static_cluster/molecule.yml
+++ b/molecule/static_cluster/molecule.yml
@@ -42,9 +42,21 @@ provisioner:
       localhost:
         ansible_python_interpreter: "{{ ansible_playbook_python }}"
       instance1:
-        activemq_ha_role: 'master'
+        activemq_ha_role: 'primary'
+        activemq_broker_connections:
+          - uri: 'tcp://instance1:61616?sslEnabled=True;keyStorePath=/opt/amq/amq-broker/etc/identity.ks;keyStorePassword=securepass;trustStorePath=/opt/amq/amq-broker/etc/trust.ks;trustStorePassword=securepass;verifyHost=False'
+            name: brokerA-2-brokerA
+            user: amq-broker
+            password: amq-broker
+            operations:
+              - type: sender
+                parameters:
+                  address_match: 'b.#'
+              - type: receiver
+                parameters:
+                  address_match: 'a.#'
       instance2:
-        activemq_ha_role: 'slave'
+        activemq_ha_role: 'backup'
   env:
     ANSIBLE_FORCE_COLOR: "true"
 verifier:

--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -293,7 +293,7 @@ activemq_broker_connections:
     operations:
       - type: mirror
         parameters:
-          queue-removal: false
+          queue_removal: false
 ```
 
 Sample for sender-receiver operation:
@@ -305,13 +305,15 @@ activemq_broker_connections:
     operations:
       - type: sender
         parameters:
-          address-match: 'queues.#'
+          address_match: 'queues.#'
       - type: receiver
         parameters:
-          address-match: 'remotequeues.#'
+          address_match: 'remotequeues.#'
 ```
 
-Notice the local queues for `remotequeues.#` need to be created on this broker.
+Note: notice how operations parameters keys are using underscore (`address_match:`) instead of dash (`address-match:`). Dash works only if using single quotes (ie. `'address-match':`)
+
+Note: the local queues for `remotequeues.#` need to be created on this broker.
 
 
 #### TLS/SSL protocol

--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -300,8 +300,10 @@ Sample for sender-receiver operation:
 
 ```yaml
 activemq_broker_connections:
-  - uri: 'tcp://<hostname>:<port>'
+  - uri: 'tcp://<hostname>:<port>?<options>'
     name: other-server
+    user: user
+    password: password
     operations:
       - type: sender
         parameters:
@@ -311,7 +313,7 @@ activemq_broker_connections:
           address_match: 'remotequeues.#'
 ```
 
-Note: notice how operations parameters keys are using underscore (`address_match:`) instead of dash (`address-match:`). Dash works only if using single quotes (ie. `'address-match':`)
+Note: operations parameters keys are using underscore (`address_match:`) instead of dash (`address-match:`). Dash works only if using single quotes (ie. `'address-match':`)
 
 Note: the local queues for `remotequeues.#` need to be created on this broker.
 

--- a/roles/activemq/templates/amq_broker.service.j2
+++ b/roles/activemq/templates/amq_broker.service.j2
@@ -23,9 +23,9 @@ TimeoutSec=600
 ExecStartPost=/usr/bin/timeout {{ activemq_systemd_wait_for_timeout }} sh -c 'while ! ss -H -t -l -n sport = :{{ activemq_port }} | grep -q "^LISTEN.*:{{ activemq_port }}"; do sleep 1; done && /bin/sleep {{ activemq_systemd_wait_for_delay }}'
 {% endif %}
 {% if activemq_systemd_wait_for_log %}
-{% if activemq_ha_enabled and activemq_ha_role == 'slave' %}
+{% if activemq_ha_enabled and (activemq_ha_role == 'slave' or activemq_ha_role == 'backup') %}
 ExecStartPost=/usr/bin/timeout {{ activemq_systemd_wait_for_timeout }} sh -c 'tail -n 15 -f {{ activemq.instance_home }}/log/artemis.log | sed "/AMQ221109/ q" && /bin/sleep {{ activemq_systemd_wait_for_delay }}'
-{% elif activemq_ha_enabled and activemq_ha_role == 'master' %}
+{% elif activemq_ha_enabled and (activemq_ha_role == 'master' or activemq_ha_role == 'primary') %}
 ExecStartPost=/usr/bin/timeout {{ activemq_systemd_wait_for_timeout }} sh -c 'tail -n 15 -f {{ activemq.instance_home }}/log/artemis.log | sed "/AMQ221001/ q" && /bin/sleep {{ activemq_systemd_wait_for_delay }}'
 {% else %}
 ExecStartPost=/usr/bin/timeout {{ activemq_systemd_wait_for_timeout }} sh -c 'tail -n 15 -f {{ activemq.instance_home }}/log/artemis.log | sed "/AMQ221034/ q" && /bin/sleep {{ activemq_systemd_wait_for_delay }}'

--- a/roles/activemq/templates/broker_connections.broker.xml.j2
+++ b/roles/activemq/templates/broker_connections.broker.xml.j2
@@ -1,4 +1,4 @@
-        <amqp-connection uri="{{ broker_connection.uri }}" name="{{ broker_connection.name }}" {% if broker_connection.user %} user="{{ broker_connection.user }}" password="{{ broker_connection.password }}"{% endif %}>
+        <amqp-connection uri="{{ broker_connection.uri }}" name="{{ broker_connection.name }}" {% if broker_connection['user'] is defined %} user="{{ broker_connection.user }}" password="{{ broker_connection.password | default(activemq_instance_password) }}"{% endif %}>
 {% for operation in broker_connection.operations | default([]) %}
             <{{ operation.type }} {% for param in lookup('ansible.builtin.dict', operation.parameters, wantlist=True) | default([]) %}{{ param.key | replace('_','-') }}="{{ param.value }}" {% endfor %}/>
 {% endfor %}

--- a/roles/activemq/templates/broker_connections.broker.xml.j2
+++ b/roles/activemq/templates/broker_connections.broker.xml.j2
@@ -1,5 +1,5 @@
-        <amqp-connection uri="{{ broker_connection.uri }}" name="{{ broker_connection.name }}">
-{% for operation in broker_connection.operation, wantlist=True) %}
-            <{{ operation.type }} {% for param in lookup('ansible.builtin.dict', broker_connection.parameters, wantlist=True) %}{{ param.key | replace('_','-') }}="{{ param.value }}" {% endfor %}/>
+        <amqp-connection uri="{{ broker_connection.uri }}" name="{{ broker_connection.name }}" {% if broker_connection.user %} user="{{ broker_connection.user }}" password="{{ broker_connection.password }}"{% endif %}>
+{% for operation in broker_connection.operations | default([]) %}
+            <{{ operation.type }} {% for param in lookup('ansible.builtin.dict', operation.parameters, wantlist=True) | default([]) %}{{ param.key | replace('_','-') }}="{{ param.value }}" {% endfor %}/>
 {% endfor %}
-        </amqp-connection>
+      </amqp-connection>

--- a/roles/activemq/templates/ha_policy.xml.j2
+++ b/roles/activemq/templates/ha_policy.xml.j2
@@ -11,7 +11,7 @@
 {% endif %}
 {% if activemq_ha_enabled and activemq_shared_storage %}
         <shared-store>
-{% if activemq_ha_role == 'slave' %}
+{% if activemq_ha_role == 'slave' or activemq_ha_role == 'backup' %}
           <slave>
             <allow-failback>true</allow-failback>
           </slave>


### PR DESCRIPTION
This changeset tackles the linked issue, and update the configuration with connection username and password. 

#### Multi-site fault-tolerance (AMQP broker connections)

| Variable | Description | Default |
|:---------|:------------|:--------|
|`activemq_broker_connections`| AMQP broker connections configuration; list of `{ name(str),uri(str),operations(list of dicts with type key in [mirror,sender,receiver,peer])) }` | `[]` |

Sample of mirroring operation:

```yaml
activemq_broker_connections:
  - uri: 'tcp://<hostname>:<port>'
    name: DC2
    sync: true
    operations:
      - type: mirror
        parameters:
          queue_removal: false
```

Sample for sender-receiver operation:

```yaml
activemq_broker_connections:
  - uri: 'tcp://<hostname>:<port>?<options>'
    name: other-server
    user: user
    password: password
    operations:
      - type: sender
        parameters:
          address_match: 'queues.#'
      - type: receiver
        parameters:
          address_match: 'remotequeues.#'
```

Note: operations parameters keys are using underscore (`address_match:`) instead of dash (`address-match:`). Dash works only if using single quotes (ie. `'address-match':`)

Note: the local queues for `remotequeues.#` need to be created on this broker.



Fix #126 