### PR TITLE
Allow to configure broker properties with properties file

### DIFF
--- a/molecule/custom_xml/converge.yml
+++ b/molecule/custom_xml/converge.yml
@@ -5,5 +5,6 @@
   vars:
     activemq_config_override_template: 'broker.xml.j2'
     activemq_jvm_package: java-11-openjdk-headless
+    activemq_properties_file: test.properties
   roles:
     - middleware_automation.amq.activemq

--- a/molecule/custom_xml/converge.yml
+++ b/molecule/custom_xml/converge.yml
@@ -6,5 +6,6 @@
     activemq_config_override_template: 'broker.xml.j2'
     activemq_jvm_package: java-11-openjdk-headless
     activemq_properties_file: test.properties
+    activemq_version: 2.36.0
   roles:
     - middleware_automation.amq.activemq

--- a/molecule/custom_xml/templates/test.properties
+++ b/molecule/custom_xml/templates/test.properties
@@ -1,0 +1,4 @@
+securityEnabled=false
+acceptorConfigurations.test.factoryClassName=org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptorFactory
+acceptorConfigurations.test.params.HOST=localhost
+acceptorConfigurations.test.params.PORT=62626

--- a/molecule/custom_xml/templates/test.properties
+++ b/molecule/custom_xml/templates/test.properties
@@ -1,4 +1,4 @@
 securityEnabled=false
 acceptorConfigurations.test.factoryClassName=org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptorFactory
-acceptorConfigurations.test.params.HOST=localhost
-acceptorConfigurations.test.params.PORT=62626
+acceptorConfigurations.test.params.host=localhost
+acceptorConfigurations.test.params.port=62626

--- a/molecule/custom_xml/verify.yml
+++ b/molecule/custom_xml/verify.yml
@@ -35,3 +35,16 @@
           - "broker_bin.stat.pw_name == 'amq-broker'"
         quiet: true
         fail_msg: "Wrong ownership of instance directories"
+
+    - name: Check all port numbers are accessible from the current host
+      wait_for:
+        host: localhost
+        port: "{{ item }}"
+        state: started
+        delay: 0
+        timeout: 10
+      ignore_errors: yes
+      loop:
+        - 8161
+        - 61616
+        - 62626

--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -85,6 +85,7 @@ Role Defaults
 |`activemq_additional_libs`| List of jars to install in activemq classpath, read from playbook files lookup paths | `[]` |
 |`activemq_mask_password_hashname`| Name of algorithm used for masking password, will be passed to custom codec | `sha1` |
 |`activemq_mask_password_iterations`| Number of iterations for masking password, will be passed to custom codec | `1024` |
+|`activemq_properties_file`| Properties file to allow updates and additions to the broker configuration after any xml has been parsed | `""` |
 
 
 #### LDAP authN/authZ

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -337,3 +337,7 @@ activemq_diverts: []
 activemq_broker_connections: []
 
 activemq_federations: []
+
+### property file name, in playbook lookup paths
+# see: https://activemq.apache.org/components/artemis/documentation/latest/configuration-index.html#broker-properties
+activemq_properties_file: ''

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -695,6 +695,10 @@ argument_specs:
                 description: "Arbitrary extra arguments for the JVM"
                 default: "-Dhawtio.disableProxy=true -Dhawtio.realm=activemq -Dhawtio.offline=true -Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal"
                 type: "str"
+            activemq_properties_file:
+                description: "Properties file to allow updates and additions to the broker configuration after any xml has been parsed"
+                default: ""
+                type: "str"
     downstream:
         options:
             amq_broker_version:

--- a/roles/activemq/tasks/configure_broker.yml
+++ b/roles/activemq/tasks/configure_broker.yml
@@ -1,15 +1,4 @@
 ---
-- name: "Configure AMQ broker logging"
-  become: true
-  ansible.builtin.template:
-    src: "{{ activemq_logger_config_template_path }}{{ activemq_logger_config_template }}"
-    dest: "{{ activemq.instance_home }}/etc/{{ activemq_logger_config_template | basename | regex_replace('[.]j2$', '') }}"
-    owner: "{{ activemq_service_user }}"
-    group: "{{ activemq_service_group }}"
-    mode: '0644'
-  notify:
-    - restart amq_broker
-
 - name: Configure ha policy
   when: activemq_ha_enabled
   block:
@@ -76,28 +65,6 @@
 - name: Configure broker connections
   ansible.builtin.include_tasks: broker_connections.yml
   when: activemq_broker_connections | length > 0
-
-- name: "Configure jolokia access"
-  become: true
-  ansible.builtin.template:
-    src: jolokia-access.xml.j2
-    dest: "{{ activemq.instance_home }}/etc/jolokia-access.xml"
-    owner: "{{ activemq_service_user }}"
-    group: "{{ activemq_service_group }}"
-    mode: '0644'
-  notify:
-    - restart amq_broker
-
-- name: "Configure jaas"
-  become: true
-  ansible.builtin.template:
-    src: "{{ activemq_auth_template }}"
-    dest: "{{ activemq.instance_home }}/etc/login.config"
-    owner: "{{ activemq_service_user }}"
-    group: "{{ activemq_service_group }}"
-    mode: '0644'
-  notify:
-    - restart amq_broker
 
 - name: "Configure prometheus metrics"
   become: true

--- a/roles/activemq/tasks/configure_files.yml
+++ b/roles/activemq/tasks/configure_files.yml
@@ -1,0 +1,45 @@
+---
+- name: "Configure AMQ broker logging"
+  become: true
+  ansible.builtin.template:
+    src: "{{ activemq_logger_config_template_path }}{{ activemq_logger_config_template }}"
+    dest: "{{ activemq.instance_home }}/etc/{{ activemq_logger_config_template | basename | regex_replace('[.]j2$', '') }}"
+    owner: "{{ activemq_service_user }}"
+    group: "{{ activemq_service_group }}"
+    mode: '0644'
+  notify:
+    - restart amq_broker
+
+- name: "Configure jolokia access"
+  become: true
+  ansible.builtin.template:
+    src: jolokia-access.xml.j2
+    dest: "{{ activemq.instance_home }}/etc/jolokia-access.xml"
+    owner: "{{ activemq_service_user }}"
+    group: "{{ activemq_service_group }}"
+    mode: '0644'
+  notify:
+    - restart amq_broker
+
+- name: "Configure jaas"
+  become: true
+  ansible.builtin.template:
+    src: "{{ activemq_auth_template }}"
+    dest: "{{ activemq.instance_home }}/etc/login.config"
+    owner: "{{ activemq_service_user }}"
+    group: "{{ activemq_service_group }}"
+    mode: '0644'
+  notify:
+    - restart amq_broker
+
+- name: "Configure using properties file"
+  become: true
+  ansible.builtin.template:
+    src: "{{ activemq_properties_file }}"
+    dest: "{{ activemq.instance_home }}/etc/{{ activemq_properties_file | basename }}"
+    owner: "{{ activemq_service_user }}"
+    group: "{{ activemq_service_group }}"
+    mode: '0644'
+  notify:
+    - restart amq_broker
+  when: activemq_properties_file != ''

--- a/roles/activemq/tasks/main.yml
+++ b/roles/activemq/tasks/main.yml
@@ -126,9 +126,12 @@
         mode: '0640'
       loop: "{{ activemq_additional_libs }}"
 
-- name: "Generate broker configuration for: {{ activemq_dest }}/{{ activemq.instance_name }}"
+- name: "Generate broker.xml configuration for: {{ activemq_dest }}/{{ activemq.instance_name }}"
   ansible.builtin.include_tasks: configure_broker.yml
   when: activemq_config_override_template == ''
+
+- name: "Generate broker config files for: {{ activemq_dest }}/{{ activemq.instance_name }}"
+  ansible.builtin.include_tasks: configure_files.yml
 
 - name: Reload systemd
   become: true

--- a/roles/activemq/tasks/systemd.yml
+++ b/roles/activemq/tasks/systemd.yml
@@ -26,6 +26,7 @@
                               if activemq_logger_config_keep_name and activemq_logger_config_template != 'log4j2.properties.j2' }}"
     activemq_jmx_opts: "{{ '-javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=0.0.0.0:' + \
                            activemq_jmx_exporter_port + ':' + activemq_jmx_exporter_config_path if activemq_jmx_exporter_enabled else '' }}"
+    activemq_properties_opts: "{{ ('-Dbroker.properties=' +  activemq.instance_home + '/etc/' + activemq_properties_file) if activemq_properties_file != '' else '' }}"
   notify:
     - restart amq_broker
 

--- a/roles/activemq/templates/amq_broker.sysconfig.j2
+++ b/roles/activemq/templates/amq_broker.sysconfig.j2
@@ -1,5 +1,5 @@
 # {{ ansible_managed }}
-JAVA_ARGS='{{ activemq_java_opts }} {{ activemq_logger_opts }} {{ activemq_jmx_opts }}'
+JAVA_ARGS='{{ activemq_java_opts }} {{ activemq_logger_opts }} {{ activemq_jmx_opts }} {{ activemq_properties_opts }}'
 JAVA_HOME={{ activemq_java_home  | default(activemq_rpm_java_home, true) }}
 HAWTIO_ROLE='{{ activemq_hawtio_role }}'
 ARTEMIS_INSTANCE_URI='file:{{ activemq.instance_home }}/'


### PR DESCRIPTION
See: https://activemq.apache.org/components/artemis/documentation/latest/configuration-index.html#broker-properties

New parameter allows the configuration of the feature:

| Variable | Description | Default |
|:---------|:------------|:--------|
|`activemq_properties_file`| Properties file to allow updates and additions to the broker configuration after any xml has been parsed | `""` |

By default the new parameter will introduce no changes. If set to a file name, the role will search for a properties file with such name in the playbook default lookup locations (note: it cannot be template); the properties file will be copied to {{ instance.home }}/etc/ and added to the start up script arguments.

