### PR TITLE
Add fact gathering module for amq

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This collection has been tested against following Ansible versions: **>=2.15.0**
 
 ### Plugins:
 
+* `activemq_facts`: return activemq configuration as ansible fact data
 * `pbkdf2_hmac`: filter plugin used internally to generate unidirectional account password hashes
 <!--end roles_paths -->
 

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -6,6 +6,16 @@
     - name: Populate service facts
       ansible.builtin.service_facts:
 
+    - name: Populate activemq facts
+      middleware_automation.amq.activemq_facts:
+        base_url: http://0.0.0.0:8161
+        auth_username: amq
+        auth_password: amqbrokerpass
+
+    - name: Print activemq gathered facts
+      ansible.builtin.debug:
+        var: ansible_facts.activemq
+
     - name: Check if amq-broker service is started
       ansible.builtin.assert:
         that:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -112,5 +112,5 @@
       ansible.builtin.assert:
         that:
           - ansible_facts.activemq.AddressNames | length > 0
-          - "client123.pubsub" in ansible_facts.activemq.AddressNames
-          - "importantTopic" in ansible_facts.activemq.AddressNames
+          - "'client123.pubsub' in ansible_facts.activemq.AddressNames"
+          - "'importantTopic' in ansible_facts.activemq.AddressNames"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -101,3 +101,16 @@
           - diverts.count == 1
         quiet: true
         fail_msg: "Failed to retrieve generated divert"
+
+    - name: Check divert configuration via jolokia
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.activemq.DivertNames | length > 0
+          - ansible_facts.activemq.DivertNames | first == "TESTDIVERT"
+
+    - name: Check queue configuration via jolokia
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.activemq.AddressNames | length > 0
+          - "client123.pubsub" in ansible_facts.activemq.AddressNames
+          - "importantTopic" in ansible_facts.activemq.AddressNames

--- a/molecule/mask_passwords/verify.yml
+++ b/molecule/mask_passwords/verify.yml
@@ -7,7 +7,7 @@
       ansible.builtin.service_facts:
 
     - name: Populate activemq facts
-      ansible.builtin.activemq_facts:
+      middleware_automation.amq.activemq_facts:
         auth_username: amq
         auth_password: amqbrokerpass
         validate_certs: false

--- a/molecule/mask_passwords/verify.yml
+++ b/molecule/mask_passwords/verify.yml
@@ -8,8 +8,8 @@
 
     - name: Populate activemq facts
       middleware_automation.amq.activemq_facts:
-        auth_username: amq
-        auth_password: amqbrokerpass
+        auth_username: tesla
+        auth_password: password
         validate_certs: false
 
     - name: Check if amq-broker service is started

--- a/molecule/mask_passwords/verify.yml
+++ b/molecule/mask_passwords/verify.yml
@@ -6,6 +6,12 @@
     - name: Populate service facts
       ansible.builtin.service_facts:
 
+    - name: Populate activemq facts
+      ansible.builtin.activemq_facts:
+        auth_username: amq
+        auth_password: amqbrokerpass
+        validate_certs: false
+
     - name: Check if amq-broker service is started
       ansible.builtin.assert:
         that:

--- a/molecule/static_cluster/converge.yml
+++ b/molecule/static_cluster/converge.yml
@@ -15,6 +15,10 @@
     activemq_tls_keystore_password: securepass
     activemq_tls_truststore_path: nfs/trust.ks
     activemq_tls_truststore_password: securepass
+    activemq_users:
+    - user: amq
+      password: amqbrokerpass
+      roles: [ amq ]
     activemq_acceptors:
       - name: artemis
         bind_address: 0.0.0.0

--- a/molecule/static_cluster/verify.yml
+++ b/molecule/static_cluster/verify.yml
@@ -7,9 +7,10 @@
 
     - name: Populate activemq facts
       middleware_automation.amq.activemq_facts:
-        base_url: http://0.0.0.0:8161
+        base_url: https://localhost:8161
         auth_username: amq
         auth_password: amqbrokerpass
+        validate_certs: false
 
     - name: Check if amq-broker service is started
       ansible.builtin.assert:
@@ -49,3 +50,20 @@
               - "'got backup lock' in slurped_log_instance2.content|b64decode"
               - "'waiting live to fail before it gets active' in slurped_log_instance2.content|b64decode or 'waiting for primary to fail before activating' in slurped_log_instance2.content|b64decode"
             quiet: true
+
+    - name: Check cluster status via jolokia facts (master)
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.activemq.Active == true
+          - ansible_facts.activemq.Backup == false
+          - ansible_facts.activemq.SharedStore == true
+          - ansible_facts.activemq.HAPolicy == "Shared Store Primary"
+      when: inventory_hostname == 'instance1'
+
+    - name: Check cluster status via jolokia facts (backup)
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.activemq.Active == false
+          - ansible_facts.activemq.Backup == true
+          - ansible_facts.activemq.SharedStore == true
+      when: inventory_hostname == 'instance2'

--- a/molecule/static_cluster/verify.yml
+++ b/molecule/static_cluster/verify.yml
@@ -5,6 +5,12 @@
     - name: Populate service facts
       ansible.builtin.service_facts:
 
+    - name: Populate activemq facts
+      middleware_automation.amq.activemq_facts:
+        base_url: http://0.0.0.0:8161
+        auth_username: amq
+        auth_password: amqbrokerpass
+
     - name: Check if amq-broker service is started
       ansible.builtin.assert:
         that:

--- a/plugins/modules/activemq_facts.py
+++ b/plugins/modules/activemq_facts.py
@@ -1,24 +1,10 @@
 # Copyright (c) 2024, Red Hat Inc.
 # Copyright (c) 2024, Guido Grazioli <ggraziol@redhat.com>
 # Apache License, Version 2.0 (see LICENSE or https://www.apache.org/licenses/LICENSE-2.0)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, annotations, division, print_function
-
+from __future__ import absolute_import, division, print_function
 __metaclass__ = type
-
-import json
-import traceback
-import os
-import platform
-import re
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.locale import get_best_parsable_locale
-from ansible.module_utils.urls import open_url, basic_auth_header
-from ansible.module_utils.six.moves.urllib.parse import urlencode, quote
-from ansible.module_utils.six.moves.urllib.error import HTTPError
-from ansible.module_utils.common.text.converters import to_native, to_text
-
 
 DOCUMENTATION = r'''
 ---
@@ -101,6 +87,19 @@ ansible_facts:
       contains:
 '''
 
+import json
+import traceback
+import os
+import platform
+import re
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.urls import open_url, basic_auth_header
+from ansible.module_utils.six.moves.urllib.parse import urlencode, quote
+from ansible.module_utils.six.moves.urllib.error import HTTPError
+from ansible.module_utils.common.text.converters import to_native, to_text
+
+
 URL_JOLOKIA_INFO = "{url}/console/jolokia/read/org.apache.activemq.artemis:broker=!%22{broker}!%22"
 
 class JolokiaService(object):
@@ -169,8 +168,6 @@ def amq_argument_spec():
 def main():
     module = AnsibleModule(argument_spec=amq_argument_spec(), supports_check_mode=True,
                            required_together=([['auth_username', 'auth_password']]))
-    locale = get_best_parsable_locale(module)
-    module.run_command_environ_update = dict(LANG=locale, LC_ALL=locale)
     mod = JolokiaService(module)
     svc = mod.gather_facts()
     if len(svc) == 0:

--- a/plugins/modules/activemq_facts.py
+++ b/plugins/modules/activemq_facts.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 # Copyright (c) 2024, Red Hat Inc.
 # Copyright (c) 2024, Guido Grazioli <ggraziol@redhat.com>
 # Apache License, Version 2.0 (see LICENSE or https://www.apache.org/licenses/LICENSE-2.0)
@@ -31,12 +33,16 @@ options:
         type: str
         required: false
         default: http://localhost:8161
+        aliases:
+          - url
     broker_name:
         description:
             - Name of the broker instance
         type: str
         required: false
         default: 'amq-broker'
+        aliases:
+          - broker
     auth_username:
         description:
             - Username to authenticate for API access with.
@@ -102,6 +108,7 @@ from ansible.module_utils.common.text.converters import to_native, to_text
 
 URL_JOLOKIA_INFO = "{url}/console/jolokia/read/org.apache.activemq.artemis:broker=!%22{broker}!%22"
 
+
 class JolokiaService(object):
 
     def __init__(self, module):
@@ -147,7 +154,6 @@ class JolokiaService(object):
             self.module.fail_json(msg='General error calling jolokia api %s' % (str(e)),
                                   exception=traceback.format_exc())
 
-        return services
 
 def amq_argument_spec():
     """

--- a/plugins/modules/activemq_facts.py
+++ b/plugins/modules/activemq_facts.py
@@ -13,8 +13,8 @@ DOCUMENTATION = r'''
 module: activemq_facts
 short_description: Return activemq configuration as fact data
 description:
-     - Return artemis activemq configuration and runtime information from the jolokia endpoint as fact data.
-version_added: 2.1
+  - Return artemis activemq configuration and runtime information from the jolokia endpoint as fact data.
+version_added: "2.1.0"
 requirements: ["A running instance of activemq with the jolokia port open"]
 extends_documentation_fragment:
   -  action_common_attributes

--- a/plugins/modules/activemq_facts.py
+++ b/plugins/modules/activemq_facts.py
@@ -14,7 +14,7 @@ module: activemq_facts
 short_description: Return activemq configuration as fact data
 description:
      - Return artemis activemq configuration and runtime information from the jolokia endpoint as fact data.
-version_added: "2.1.1"
+version_added: 2.1
 requirements: ["A running instance of activemq with the jolokia port open"]
 extends_documentation_fragment:
   -  action_common_attributes

--- a/plugins/modules/activemq_facts.py
+++ b/plugins/modules/activemq_facts.py
@@ -26,6 +26,8 @@ attributes:
         support: none
     facts:
         support: full
+    platforms:
+        support: posix
 options:
     base_url:
         description:
@@ -87,23 +89,18 @@ ansible_facts:
   type: complex
   contains:
     activemq:
-      description:
+      description: THe factual representation of an activemq instance configuration
       returned: always
       type: dict
-      contains:
 '''
 
 import json
 import traceback
-import os
-import platform
-import re
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import open_url, basic_auth_header
-from ansible.module_utils.six.moves.urllib.parse import urlencode, quote
 from ansible.module_utils.six.moves.urllib.error import HTTPError
-from ansible.module_utils.common.text.converters import to_native, to_text
+from ansible.module_utils.common.text.converters import to_native
 
 
 URL_JOLOKIA_INFO = "{url}/console/jolokia/read/org.apache.activemq.artemis:broker=!%22{broker}!%22"

--- a/plugins/modules/activemq_facts.py
+++ b/plugins/modules/activemq_facts.py
@@ -173,10 +173,10 @@ def main():
                            required_together=([['auth_username', 'auth_password']]))
     mod = JolokiaService(module)
     svc = mod.gather_facts()
-    if not svc or not "value" in svc:
+    if not svc or "value" not in svc:
         results = dict(skipped=True, msg="Failed to find info. This can be due to privileges or some other configuration issue.")
     else:
-        results = dict(ansible_facts=dict(activemq=svc.value))
+        results = dict(ansible_facts=dict(activemq=svc["value"]))
     module.exit_json(**results)
 
 

--- a/plugins/modules/activemq_facts.py
+++ b/plugins/modules/activemq_facts.py
@@ -173,10 +173,10 @@ def main():
                            required_together=([['auth_username', 'auth_password']]))
     mod = JolokiaService(module)
     svc = mod.gather_facts()
-    if len(svc) == 0:
+    if not svc or not "value" in svc:
         results = dict(skipped=True, msg="Failed to find info. This can be due to privileges or some other configuration issue.")
     else:
-        results = dict(ansible_facts=dict(activemq=svc))
+        results = dict(ansible_facts=dict(activemq=svc.value))
     module.exit_json(**results)
 
 

--- a/plugins/modules/activemq_facts.py
+++ b/plugins/modules/activemq_facts.py
@@ -27,7 +27,7 @@ attributes:
     facts:
         support: full
     platform:
-        support: N/A
+        platforms: all
 options:
     base_url:
         description:

--- a/plugins/modules/activemq_facts.py
+++ b/plugins/modules/activemq_facts.py
@@ -130,7 +130,7 @@ class JolokiaService(object):
 
         restheaders = {}
         restheaders["Authorization"] = basic_auth_header(self.auth_username, self.auth_password)
-        restheaders['Origin'] = self.baseurl
+        restheaders['Origin'] = self.baseurl if 'localhost' not in self.baseurl else 'https://0.0.0.0'
 
         try:
             return json.loads(to_native(open_url(jolokia_url, method='GET',

--- a/plugins/modules/activemq_facts.py
+++ b/plugins/modules/activemq_facts.py
@@ -1,0 +1,184 @@
+# Copyright (c) 2024, Red Hat Inc.
+# Copyright (c) 2024, Guido Grazioli <ggraziol@redhat.com>
+# Apache License, Version 2.0 (see LICENSE or https://www.apache.org/licenses/LICENSE-2.0)
+
+from __future__ import absolute_import, annotations, division, print_function
+
+__metaclass__ = type
+
+import json
+import traceback
+import os
+import platform
+import re
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.locale import get_best_parsable_locale
+from ansible.module_utils.urls import open_url, basic_auth_header
+from ansible.module_utils.six.moves.urllib.parse import urlencode, quote
+from ansible.module_utils.six.moves.urllib.error import HTTPError
+from ansible.module_utils.common.text.converters import to_native, to_text
+
+
+DOCUMENTATION = r'''
+---
+module: activemq_facts
+short_description: Return activemq configuration as fact data
+description:
+     - Return artemis activemq configuration and runtime information from the jolokia endpoint as fact data.
+version_added: "2.1.1"
+requirements: ["A running instance of activemq with the jolokia port open"]
+extends_documentation_fragment:
+  -  action_common_attributes
+  -  action_common_attributes.facts
+attributes:
+    check_mode:
+        support: full
+    diff_mode:
+        support: none
+    facts:
+        support: full
+options:
+    base_url:
+        description:
+            - URL to the activemq instance.
+        type: str
+        required: false
+        default: http://localhost:8161
+    broker_name:
+        description:
+            - Name of the broker instance
+        type: str
+        required: false
+        default: 'amq-broker'
+    auth_username:
+        description:
+            - Username to authenticate for API access with.
+        type: str
+        required: true
+        aliases:
+          - username
+    auth_password:
+        description:
+            - Password to authenticate for API access with.
+        type: str
+        required: true
+        aliases:
+          - password
+    validate_certs:
+        description:
+            - Verify TLS certificates when using https.
+        type: bool
+        default: true
+    connection_timeout:
+        description:
+            - Controls the HTTP connections timeout period in seconds to jolokia API.
+        type: int
+        default: 10
+author:
+  - Guido Grazioli (@guidograzioli)
+'''
+
+EXAMPLES = r'''
+- name: Populate activemq facts
+  middleware_automation.amq.activemq_facts:
+
+- name: Print activemq service facts
+  ansible.builtin.debug:
+    var: ansible_facts.activemq
+'''
+
+RETURN = r'''
+ansible_facts:
+  description: Facts to add to ansible_facts about the activemq service
+  returned: always
+  type: complex
+  contains:
+    activemq:
+      description:
+      returned: always
+      type: dict
+      contains:
+'''
+
+URL_JOLOKIA_INFO = "{url}/console/jolokia/read/org.apache.activemq.artemis:broker=!%22{broker}!%22"
+
+class JolokiaService(object):
+
+    def __init__(self, module):
+        self.module = module
+        self.baseurl = self.module.params.get('base_url')
+        self.broker = self.module.params.get('broker_name')
+        self.validate_certs = self.module.params.get('validate_certs')
+        self.connection_timeout = self.module.params.get('connection_timeout')
+        self.auth_username = self.module.params.get('auth_username')
+        self.auth_password = self.module.params.get('auth_password')
+
+    def gather_facts(self):
+        """ Obtain configuration from jolokia API
+
+        :return: dict of real, representation or None if none matching exist
+        """
+
+        jolokia_url = URL_JOLOKIA_INFO.format(url=self.baseurl, broker=self.broker)
+
+        if not self.baseurl.lower().startswith(('http', 'https')):
+            raise ValueError("base url '%s' should either start with 'http' or 'https'." % self.baseurl)
+
+        restheaders = {}
+        restheaders["Authorization"] = basic_auth_header(self.auth_username, self.auth_password)
+        restheaders['Origin'] = self.baseurl
+
+        try:
+            return json.loads(to_native(open_url(jolokia_url, method='GET',
+                                                 headers=restheaders,
+                                                 timeout=self.connection_timeout,
+                                                 validate_certs=self.validate_certs).read()))
+
+        except HTTPError as e:
+            if e.code == 404:
+                return None
+            else:
+                self.module.fail_json(msg='HTTP error calling jolokia api: %s' % (str(e)),
+                                      exception=traceback.format_exc())
+        except ValueError as e:
+            self.module.fail_json(msg='API returned incorrect JSON: %s' % (str(e)),
+                                  exception=traceback.format_exc())
+        except Exception as e:
+            self.module.fail_json(msg='General error calling jolokia api %s' % (str(e)),
+                                  exception=traceback.format_exc())
+
+        return services
+
+def amq_argument_spec():
+    """
+    Returns argument_spec of options
+
+    :return: argument_spec dict
+    """
+    return dict(
+        base_url=dict(type='str', aliases=['url'], required=False, default="http://localhost:8161", no_log=False),
+        broker_name=dict(type='str', aliases=['broker'], required=False, default="amq-broker"),
+        auth_username=dict(type='str', aliases=['username'], required=True),
+        auth_password=dict(type='str', aliases=['password'], required=True, no_log=True),
+        validate_certs=dict(type='bool', default=True),
+        connection_timeout=dict(type='int', default=10)
+    )
+
+
+def main():
+    module = AnsibleModule(argument_spec=amq_argument_spec(), supports_check_mode=True,
+                           required_together=([['auth_username', 'auth_password']]))
+    locale = get_best_parsable_locale(module)
+    module.run_command_environ_update = dict(LANG=locale, LC_ALL=locale)
+    mod = JolokiaService(module)
+    svc = mod.gather_facts()
+    if len(svc) == 0:
+        results = dict(skipped=True, msg="Failed to find info. This can be due to privileges or some other configuration issue.")
+    else:
+        results = dict(ansible_facts=dict(activemq=svc))
+    module.exit_json(**results)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/activemq_facts.py
+++ b/plugins/modules/activemq_facts.py
@@ -89,7 +89,7 @@ ansible_facts:
   type: complex
   contains:
     activemq:
-      description: THe factual representation of an activemq instance configuration
+      description: The factual representation of an activemq instance configuration.
       returned: always
       type: dict
 '''

--- a/plugins/modules/activemq_facts.py
+++ b/plugins/modules/activemq_facts.py
@@ -26,8 +26,8 @@ attributes:
         support: none
     facts:
         support: full
-    platforms:
-        support: posix
+    platform:
+        support: N/A
 options:
     base_url:
         description:


### PR DESCRIPTION
The new module calls into the jolokia API and returns activemq configuration / runtime info as Ansible facts.

Sample usage:

```yaml
- name: Populate activemq facts
  middleware_automation.amq.activemq_facts:
    base_url: http://0.0.0.0:8161
    auth_username: ...
    auth_password: ...

- name: Print activemq gathered facts
  ansible.builtin.debug:
    var: ansible_facts.activemq
```

returns:

```
TASK [debug] *******************************************************************
task path: /home/guido/Development/redhat/amq/molecule/default/verify.yml:15
ok: [instance] => {
    "ansible_facts.activemq": {
        "Acceptors": [
            [
                "artemis",
                "org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptorFactory",
                {
                    "host": "localhost",
                    "port": "61616",
                    "protocols": "CORE,MQTT",
                    "scheme": "tcp",
                    "tcpReceiveBufferSize": "1048576",
                    "tcpSendBufferSize": "1048576",
                    "useEpoll": "True"
                }
            ],
            [
                "amqp",
                "org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptorFactory",
                {
        [...]
        "PersistenceEnabled": true,
        "QueueCount": 6,
        "QueueNames": [
            "$sys.mqtt.sessions",
            "DLQ",
            "queue.out",
            "client123.pubsub.foo",
            "ExpiryQueue",
            "queue.in"
        ],
        "ReplicaSync": false,
        "ScheduledThreadPoolMaxSize": 5,
        "SecurityEnabled": true,
        "SecurityInvalidationInterval": 10000,
        "SharedStore": false,
        "Started": true,
        "Status": "{\"configuration\":{\"properties\":{\"system-brokerconfig.\":{\"alder32\":\"1\"}}},\"server\":{\"jaas\":{\"properties\":{\"artemis-users.properties\":{\"reloadTime\":\"1723459747305\",\"Alder32\":\"2937610211\"},\"artemis-roles.properties\":{\"reloadTime\":\"1723459747305\",\"Alder32\":\"3310360534\"}}},\"state\":\"STARTED\",\"version\":\"2.34.0\",\"nodeId\":\"893d5e73-5890-11ef-a186-0242ac110002\",\"identity\":null,\"uptime\":\"2 hours 32 minutes\"}}",
        "ThreadPoolMaxSize": 30,
        "TotalConnectionCount": 8,
        "TotalConsumerCount": 0,
        "TotalMessageCount": 0,
        "TotalMessagesAcknowledged": 0,
        "TotalMessagesAdded": 0,
        "TransactionTimeout": 300000,
        "TransactionTimeoutScanPeriod": 1000,
        "Uptime": "2 hours 32 minutes",
        "UptimeMillis": 9121059,
        "Version": "2.34.0",
        "WildcardRoutingEnabled": true
```