### PR TITLE
Add ha with replication policy

### DIFF
--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -270,7 +270,7 @@ Sample divert:
 |`activemq_cluster_maxhops`| Cluster max hops | `1` |
 |`activemq_cluster_lb_policy`| Policy for cluster load balancing | `ON_DEMAND` |
 |`activemq_ha_role` | Instance role for high availability | `live-only` |
-|`activemq_replicate`| Enables replication | `False` |
+|`activemq_replication`| Enables replication | `False` |
 |`activemq_replicated`| Designate instance as replicated node | `False` |
 |`activemq_cluster_discovery` | Cluster discovery: [`jgroups` (shared file ping), `multicast` (UDP), `static` (node list)] | `static` |
 |`activemq_cluster_iface` | The NIC name to be used for cluster IPv4 addresses (ie. 'eth0') | `default_ipv4` |

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -58,7 +58,7 @@ activemq_cluster_pass: amq-cluster-pass
 activemq_cluster_maxhops: 1
 activemq_cluster_lb_policy: ON_DEMAND
 activemq_cluster_iface: default_ipv4
-activemq_replicate: False
+activemq_replication: False
 activemq_replicated: False
 # cluster discovery: ['jgroups' for shared file ping, 'multicast' for UDP multicast, 'static' for static declaration]
 activemq_cluster_discovery: static

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -199,7 +199,7 @@ argument_specs:
                 default: "default_ipv4"
                 description: "The NIC name to be used for cluster IPv4 addresses (ie. 'eth0')."
                 type: "str"
-            activemq_replicate:
+            activemq_replication:
                 # line 50 of defaults/main.yml
                 default: false
                 description: "Enables replication"

--- a/roles/activemq/tasks/configure_artemis.yml
+++ b/roles/activemq/tasks/configure_artemis.yml
@@ -84,14 +84,14 @@
     activemq_options:
       - "{{ activemq_options | join(' ') }}"
       - "--slave"
-  when: activemq_replicate
+  when: activemq_replicated
 
 - name: Enable replication
   ansible.builtin.set_fact:
     activemq_options:
       - "{{ activemq_options | join(' ') }}"
       - "--replicated"
-  when: activemq_replicated
+  when: activemq_replication
 
 - name: Enable shared storage
   ansible.builtin.set_fact:

--- a/roles/activemq/templates/ha_policy.xml.j2
+++ b/roles/activemq/templates/ha_policy.xml.j2
@@ -1,4 +1,4 @@
-{% if activemq_ha_enabled and not activemq_replicate and not activemq_shared_storage %}
+{% if activemq_ha_enabled and not activemq_replication and not activemq_shared_storage %}
         <live-only>
             <scale-down>
 {% for param in activemq_connectors %}
@@ -12,13 +12,26 @@
 {% if activemq_ha_enabled and activemq_shared_storage %}
         <shared-store>
 {% if activemq_ha_role == 'slave' or activemq_ha_role == 'backup' %}
-          <slave>
+          <{{ activemq_ha_role }}>
             <allow-failback>true</allow-failback>
-          </slave>
+          </{{ activemq_ha_role }}>
 {% else %}
           <master>
             <failover-on-shutdown>true</failover-on-shutdown>
           </master>
 {% endif %}
         </shared-store>
+{% endif %}
+{% if activemq_ha_enabled and activemq_replication %}
+        <replication>
+{% if activemq_ha_role == 'slave' or activemq_ha_role == 'backup' or amq_broker_replicated %}
+          <{{ activemq_ha_role }}>
+            <allow-failback>true</allow-failback>
+          </{{ activemq_ha_role }}>
+{% else %}
+          <master>
+            <check-for-live-server>true</check-for-live-server>
+          </master>
+{% endif %}
+        </replication>
 {% endif %}


### PR DESCRIPTION
HA policy is set by the following parameters:

| Variable | Description | Default |
|:---------|:------------|:--------|
|`activemq_ha_enabled`| Whether to enable ha | `false` |
|`activemq_replication`| Enables replication | `false` |
|`activemq_replicated`| Designate instance as replicated node | `false` |

To designate nodes as replicas, use the `activemq_replicated` above in the node host_vars, or alternatively you can use
`activemq_ha_role` and assign to `primary` and `backup`
