### PR TITLE
Add network check parameters

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,6 +4,8 @@
   gather_facts: yes
   vars:
     activemq_service_user_home: /home/activemq
+    activemq_network_check_enabled: true
+    activemq_network_check_list: '127.0.0.1,8.8.8.8'
     activemq_hawtio_role: admin
     activemq_users:
       - user: amq

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -5,7 +5,7 @@
   vars:
     activemq_service_user_home: /home/activemq
     activemq_network_check_enabled: true
-    activemq_network_check_list: '127.0.0.1,8.8.8.8'
+    activemq_network_check_list: '127.0.0.1,8.8.8.8,{{ inventory_hostname }}'
     activemq_hawtio_role: admin
     activemq_users:
       - user: amq

--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -321,6 +321,19 @@ Note: operations parameters keys are using underscore (`address_match:`) instead
 Note: the local queues for `remotequeues.#` need to be created on this broker.
 
 
+#### Network check
+
+| Variable | Description | Default |
+|:---------|:------------|:--------|
+|`activemq_network_check_enabled`| Whether to enable network check | `false` |
+|`activemq_network_check_period`| How often to check network reachability (ms) | `10000` |
+|`activemq_network_check_timeout`| Connection timeout for network checks (ms) | `1000` |
+|`activemq_network_check_list`| The addresses to use for checking; comma separated list, no spaces, just DNS or IPs | `''` |
+|`activemq_network_check_NIC`| The network card to use for network checking | `''` |
+|`activemq_network_check_ping_command`| The ping command to network check IPv4 | `''` |
+|`activemq_network_check_ping6_command`|The ping command to network check IPv6 | `''` |
+
+
 #### TLS/SSL protocol
 
 | Variable | Description | Default |

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -338,6 +338,16 @@ activemq_broker_connections: []
 
 activemq_federations: []
 
-### property file name, in playbook lookup paths
+### Property file name, in playbook lookup paths
 # see: https://activemq.apache.org/components/artemis/documentation/latest/configuration-index.html#broker-properties
 activemq_properties_file: ''
+
+### Pinging the network
+# see: https://activemq.apache.org/components/artemis/documentation/latest/network-isolation.html#pinging-the-network
+activemq_network_check_enabled: false
+activemq_network_check_period: 10000
+activemq_network_check_timeout: 1000
+activemq_network_check_list: '' # this is comma separated list, no spaces, just DNS or IPs
+activemq_network_check_NIC: '' # the network card to use for network checking
+activemq_network_check_ping_command: ''
+activemq_network_check_ping6_command: ''

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -348,6 +348,6 @@ activemq_network_check_enabled: false
 activemq_network_check_period: 10000
 activemq_network_check_timeout: 1000
 activemq_network_check_list: '' # this is comma separated list, no spaces, just DNS or IPs
-activemq_network_check_NIC: '' # the network card to use for network checking
+activemq_network_check_NIC: '' # noqa var-naming[pattern] # the network card to use for network checking
 activemq_network_check_ping_command: ''
 activemq_network_check_ping6_command: ''

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -657,6 +657,34 @@ argument_specs:
                 description: "Properties file to allow updates and additions to the broker configuration after any xml has been parsed"
                 default: ""
                 type: "str"
+            activemq_network_check_enabled:
+                default: false
+                type: "bool"
+                description: "Whether to enable network check"
+            activemq_network_check_period:
+                default: 10000
+                type: int
+                description: 'How often to check network reachability (ms)'
+            activemq_network_check_timeout:
+                default: 1000
+                type: int
+                description: 'Connection timeout for network checks (ms)'
+            activemq_network_check_list:
+                default: ''
+                type: "str"
+                description: 'The addresses to use for checking; comma separated list, no spaces, just DNS or IPs'
+            activemq_network_check_NIC:
+                default: ''
+                type: "str"
+                description: 'The network card to use for network checking'
+            activemq_network_check_ping_command:
+                default: ''
+                type: "str"
+                description: 'The ping command to network check IPv4'
+            activemq_network_check_ping6_command:
+                default: ''
+                type: "str"
+                description: 'The ping command to network check IPv6'
     systemd:
         options:
             activemq_version:

--- a/roles/activemq/tasks/configure_broker.yml
+++ b/roles/activemq/tasks/configure_broker.yml
@@ -44,6 +44,10 @@
 - name: Configure journal
   ansible.builtin.include_tasks: journal.yml
 
+- name: Configure network check
+  ansible.builtin.include_tasks: network_check.yml
+  when: activemq_network_check_enabled
+
 - name: Create user and roles
   ansible.builtin.include_tasks: user_roles.yml
   when: activemq_users | length > 0
@@ -61,7 +65,7 @@
 - name: Configure federations
   ansible.builtin.include_tasks: federations.yml
   when: activemq_federations | length > 0
-  
+
 - name: Configure broker connections
   ansible.builtin.include_tasks: broker_connections.yml
   when: activemq_broker_connections | length > 0

--- a/roles/activemq/tasks/network_check.yml
+++ b/roles/activemq/tasks/network_check.yml
@@ -1,0 +1,16 @@
+---
+- name: Set network check configuration
+  middleware_automation.common.xml:
+    path: "{{ activemq.instance_home }}/etc/broker.xml"
+    xpath: "/conf:configuration/core:core/core:network-check-{{ item | replace('_','-') }}"
+    value: "{{ lookup('ansible.builtin.vars', 'activemq_network_check_' + item) | to_json | replace('\"','') }}"
+    namespaces:
+      conf: urn:activemq
+      core: urn:activemq:core
+    pretty_print: true
+  become: true
+  notify:
+    - restart amq_broker
+  loop: "{{ valid_nc_configuration_list }}"
+  loop_control:
+    label: "network-check-{{ item }}"

--- a/roles/activemq/tasks/validate_config.yml
+++ b/roles/activemq/tasks/validate_config.yml
@@ -21,7 +21,7 @@
   loop_control:
     label: "{{ item }}"
 
-- name: Validate network chek configuration
+- name: Validate network check configuration
   ansible.builtin.include_tasks: validate_network_check.yml
   when: activemq_network_check_enabled
   loop:

--- a/roles/activemq/tasks/validate_config.yml
+++ b/roles/activemq/tasks/validate_config.yml
@@ -12,11 +12,25 @@
     validate_diverts: []
     validate_broker_connections: []
     valid_core_configuration_list: []
+    valid_nc_configuration_list: []
     validate_federations: []
 
 - name: Validate configuration/core and journal configuration
   ansible.builtin.include_tasks: validate_core_config.yml
   loop: "{{ activemq_core_configuration_list }}"
+  loop_control:
+    label: "{{ item }}"
+
+- name: Validate network chek configuration
+  ansible.builtin.include_tasks: validate_network_check.yml
+  when: activemq_network_check_enabled
+  loop:
+    - period
+    - timeout
+    - list
+    - NIC
+    - ping_command
+    - ping6_command
   loop_control:
     label: "{{ item }}"
 

--- a/roles/activemq/tasks/validate_network_check.yml
+++ b/roles/activemq/tasks/validate_network_check.yml
@@ -1,5 +1,5 @@
 ---
-- name: Add configuration element only if valid
+- name: Add configuration element only if valid and non-empty
   delegate_to: localhost
   run_once: true
   block:

--- a/roles/activemq/tasks/validate_network_check.yml
+++ b/roles/activemq/tasks/validate_network_check.yml
@@ -6,14 +6,15 @@
     - name: Create configuration element
       middleware_automation.common.xml:
         xsd_path: "{{ local_path.stat.path }}/artemis-configuration.xsd"
-        xmlstring: "<core xmlns=\"urn:activemq:core\"><{{ item | replace('_', '-') }}>{{ value }}</{{ item | replace('_', '-') }}></core>"
+        xmlstring: "<core xmlns=\"urn:activemq:core\"><network-check-{{ item | replace('_', '-') }}>{{ value }}</network-check-{{ item | replace('_', '-') }}></core>"
         validate: true
         input_type: xml
       vars:
-        value: "{{ lookup('ansible.builtin.vars', 'activemq_' + item) | to_json | replace('\"', '') }}"
+        value: "{{ lookup('ansible.builtin.vars', 'activemq_network_check_' + item) | to_json | replace('\"', '') }}"
     - name: "Add item {{ item }} to valid element list"
       ansible.builtin.set_fact:
-        valid_core_configuration_list: "{{ valid_core_configuration_list | default([]) + [ item ] }}"
+        valid_nc_configuration_list: "{{ valid_nc_configuration_list | default([]) + [ item ] }}"
+      when: lookup('ansible.builtin.vars', 'activemq_network_check_' + item) != ''
   rescue:
     - name: Display warning
       ansible.builtin.debug:

--- a/roles/activemq/vars/main.yml
+++ b/roles/activemq/vars/main.yml
@@ -15,7 +15,9 @@ activemq:  # noqa var-naming false positive
   instance_home: "{{ activemq_dest }}/{{ activemq_instance_name }}"
   config_xsd: "https://github.com/apache/activemq-artemis/raw/{{ activemq_version }}/artemis-server/src/main/resources/schema/artemis-configuration.xsd"
   server_xsd: "https://github.com/apache/activemq-artemis/raw/{{ activemq_version }}/artemis-server/src/main/resources/schema/artemis-server.xsd"
-  package_list: "{{ activemq_base_package_list + [activemq_jvm_package] + ([activemq_jmx_exporter_package] if activemq_jmx_exporter_enabled else []) }}"
+  package_list: "{{ activemq_base_package_list + [activemq_jvm_package] + \
+                   ([activemq_jmx_exporter_package] if activemq_jmx_exporter_enabled else []) + \
+                   (['iputils'] if activemq_network_check_enabled else []) }}"
   prometheus_package: "{{ 'com.redhat.amq.broker.' if amq_broker_enable is defined and amq_broker_enable and activemq_version.split('.')[1] | int >= 11 else 'org.apache.activemq.artemis.' }}"
 
 activemq_base_package_list:

--- a/roles/activemq_uninstall/defaults/main.yml
+++ b/roles/activemq_uninstall/defaults/main.yml
@@ -1,25 +1,25 @@
 ---
 ### Parameters as used with activemq role
-activemq_version: 2.34.0
-activemq_archive: "apache-artemis-{{ activemq_version }}-bin.zip"
-activemq_installdir: "{{ activemq_dest }}/apache-artemis-{{ activemq_version }}"
-activemq_dest: /opt/amq
-activemq_service_user: amq-broker
-activemq_service_group: amq-broker
-activemq_service_user_home: "{{ activemq_dest }}/apache-artemis-{{ activemq_version }}"
-activemq_instance_name: amq-broker
-activemq_service_pidfile: data/artemis.pid
-activemq_configure_firewalld: false
-activemq_name: 'Apache ActiveMQ'
-activemq_service_name: activemq
-activemq_data_directory: "{{ activemq_shared_storage_path if activemq_shared_storage else activemq_dest + '/' + activemq_instance_name  + '/data' }}"
-activemq_paging_directory: "{{ activemq_data_directory }}/paging"
-activemq_bindings_directory: "{{ activemq_data_directory }}/bindings"
-activemq_journal_directory: "{{ activemq_data_directory }}/journal"
-activemq_large_messages_directory: "{{ activemq_data_directory }}/largemessages"
-activemq_shared_storage: false
-activemq_shared_storage_mounted: true
-activemq_shared_storage_path: "{{ activemq_dest }}/{{ activemq_instance_name }}/data/shared"
+activemq_version: 2.34.0 # noqa var-naming[no-role-prefix] used as is in activemq role
+activemq_archive: "apache-artemis-{{ activemq_version }}-bin.zip" # noqa var-naming[no-role-prefix] used as is in activemq role
+activemq_installdir: "{{ activemq_dest }}/apache-artemis-{{ activemq_version }}" # noqa var-naming[no-role-prefix] used as is in activemq role
+activemq_dest: /opt/amq # noqa var-naming[no-role-prefix] used as is in activemq role
+activemq_service_user: amq-broker # noqa var-naming[no-role-prefix] used as is in activemq role
+activemq_service_group: amq-broker # noqa var-naming[no-role-prefix] used as is in activemq role
+activemq_service_user_home: "{{ activemq_dest }}/apache-artemis-{{ activemq_version }}" # noqa var-naming[no-role-prefix] used as is in activemq role
+activemq_instance_name: amq-broker # noqa var-naming[no-role-prefix] used as is in activemq role
+activemq_service_pidfile: data/artemis.pid # noqa var-naming[no-role-prefix] used as is in activemq role
+activemq_configure_firewalld: false # noqa var-naming[no-role-prefix] used as is in activemq role
+activemq_name: 'Apache ActiveMQ' # noqa var-naming[no-role-prefix] used as is in activemq role
+activemq_service_name: activemq # noqa var-naming[no-role-prefix] used as is in activemq role
+activemq_data_directory: "{{ activemq_shared_storage_path if activemq_shared_storage else activemq_dest + '/' + activemq_instance_name  + '/data' }}" # noqa var-naming[no-role-prefix] used as is in activemq role
+activemq_paging_directory: "{{ activemq_data_directory }}/paging" # noqa var-naming[no-role-prefix] used as is in activemq role
+activemq_bindings_directory: "{{ activemq_data_directory }}/bindings" # noqa var-naming[no-role-prefix] used as is in activemq role
+activemq_journal_directory: "{{ activemq_data_directory }}/journal" # noqa var-naming[no-role-prefix] used as is in activemq role
+activemq_large_messages_directory: "{{ activemq_data_directory }}/largemessages" # noqa var-naming[no-role-prefix] used as is in activemq role
+activemq_shared_storage: false # noqa var-naming[no-role-prefix] used as is in activemq role
+activemq_shared_storage_mounted: true # noqa var-naming[no-role-prefix] used as is in activemq role
+activemq_shared_storage_path: "{{ activemq_dest }}/{{ activemq_instance_name }}/data/shared" # noqa var-naming[no-role-prefix] used as is in activemq role
 
 ### Parameters specific to uninstall role
 # skip user/group deletion


### PR DESCRIPTION
New parameters to configure network checks:

#### Network check

| Variable | Description | Default |
|:---------|:------------|:--------|
|`activemq_network_check_enabled`| Whether to enable network check | `false` |
|`activemq_network_check_period`| How often to check network reachability (ms) | `10000` |
|`activemq_network_check_timeout`| Connection timeout for network checks (ms) | `1000` |
|`activemq_network_check_list`| The addresses to use for checking; comma separated list, no spaces, just DNS or IPs | `''` |
|`activemq_network_check_NIC`| The network card to use for network checking | `''` |
|`activemq_network_check_ping_command`| The ping command to network check IPv4 | `''` |
|`activemq_network_check_ping6_command`|The ping command to network check IPv6 | `''` |

See: https://activemq.apache.org/components/artemis/documentation/latest/network-isolation.html#pinging-the-network