### PR TITLE
Allow to configure message counters

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -5,6 +5,7 @@
   vars:
     activemq_service_user_home: /home/activemq
     activemq_network_check_enabled: true
+    activemq_message_counter_enabled: true
     activemq_network_check_list: '127.0.0.1,8.8.8.8,{{ inventory_hostname }}'
     activemq_hawtio_role: admin
     activemq_users:

--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -386,6 +386,9 @@ See _Role Variables_ below for additional TLS/SSL settings.
 |`activemq_config_xml`| Broker instance configuration file | `amq-broker.xml` |
 |`activemq_config_override_template`| Filename of custom broker xml configuration file to be deployed | `''` |
 |`activemq_service_override_template`| Filename of custom systemd unit template to be deployed | `''` |
+|`activemq_message_counter_enabled`| Whether to enable the message counters | `false` |
+|`activemq_message_counter_sample_period`| The sample period (in ms) to use for message counters| `10000` |
+|`activemq_message_counter_max_day_history`| How many days to keep message counter history| `10` |
 
 
 #### User / Role configuration

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -351,3 +351,8 @@ activemq_network_check_list: '' # this is comma separated list, no spaces, just 
 activemq_network_check_NIC: '' # noqa var-naming[pattern] # the network card to use for network checking
 activemq_network_check_ping_command: ''
 activemq_network_check_ping6_command: ''
+
+### Message counter
+activemq_message_counter_enabled: false
+activemq_message_counter_sample_period: 10000
+activemq_message_counter_max_day_history: 10

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -685,6 +685,18 @@ argument_specs:
                 default: ''
                 type: "str"
                 description: 'The ping command to network check IPv6'
+            activemq_message_counter_enabled:
+                default: false
+                type: "bool"
+                description: "Whether to enable the message counters"
+            activemq_message_counter_sample_period:
+                default: 10000
+                type: int
+                description: "The sample period (in ms) to use for message counters"
+            activemq_message_counter_max_day_history:
+                default: 10
+                type: int
+                description: "How many days to keep message counter history"
     systemd:
         options:
             activemq_version:

--- a/roles/activemq/vars/main.yml
+++ b/roles/activemq/vars/main.yml
@@ -50,3 +50,6 @@ activemq_core_configuration_list:
   - global_max_messages
   - global_max_size
   - password_codec
+  - message_counter_enabled
+  - message_counter_sample_period
+  - message_counter_max_day_history


### PR DESCRIPTION
New parameters to configure message counters:

| Variable | Description | Default |
|:---------|:------------|:--------|
|`activemq_message_counter_enabled`| Whether to enable the message counters | `false` |
|`activemq_message_counter_sample_period`| The sample period (in ms) to use for message counters| `10000` |
|`activemq_message_counter_max_day_history`| How many days to keep message counter history| `10` |