### PR TITLE
Add additional ha-policy parameters

### DIFF
--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -278,6 +278,12 @@ Sample divert:
 |`activemq_systemd_wait_for_log` | Whether systemd unit should wait for service to be up in logs | `True` when `activemq_ha_enabled` and `activemq_shared_storage` are both `True` |
 |`activemq_systemd_wait_for_timeout`| How long to wait for service to be alive (seconds) | `60` |
 |`activemq_systemd_wait_for_delay`| Activation delay for service systemd unit | `10` |
+|`activemq_ha_allow_failback`| Whether a server will automatically stop when another places a request to take over its place |`true` |
+|`activemq_ha_failover_on_shutdown`| Will this backup server become active on a normal server shutdown  | `true` |
+|`activemq_ha_restart_backup`| Will this server, if a backup, restart once it has been stopped because of failback or scaling down | `false` |
+|`activemq_ha_check_for_active_server`| Whether to check the cluster for a live server using our own server ID when starting up. This option is only necessary for performing 'fail-back' on replicating servers | `false` |
+|`activemq_ha_replication_cluster_name`| Name of the cluster configuration to use for replication. This setting is only necessary in case you configure multiple cluster connections | `""` |
+|`activemq_ha_replication_group_name`| With replication, if set, remote backup servers will only pair with primary servers with matching group-name | `""` |
 
 
 #### Multi-site fault-tolerance (AMQP broker connections)

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -67,6 +67,13 @@ activemq_systemd_wait_for_log: "{{ activemq_ha_enabled and activemq_shared_stora
 activemq_systemd_wait_for_timeout: 60
 activemq_systemd_wait_for_delay: 10
 activemq_ha_role: live-only
+activemq_ha_allow_failback: true
+activemq_ha_failover_on_shutdown: true
+activemq_ha_restart_backup: false
+activemq_ha_check_for_active_server: false
+activemq_ha_replication_cluster_name: "{{ activemq_instance_name }}"
+activemq_ha_replication_group_name: "{{ activemq_instance_name }}"
+
 
 ### Masked passwords
 activemq_password_codec: 'org.apache.activemq.artemis.utils.DefaultSensitiveStringCodec'

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -70,9 +70,9 @@ activemq_ha_role: live-only
 activemq_ha_allow_failback: true
 activemq_ha_failover_on_shutdown: true
 activemq_ha_restart_backup: false
-activemq_ha_check_for_active_server: false
-activemq_ha_replication_cluster_name: "{{ activemq_instance_name }}"
-activemq_ha_replication_group_name: "{{ activemq_instance_name }}"
+activemq_ha_check_for_active_server: "{{ activemq_replication }}"
+activemq_ha_replication_cluster_name: ''
+activemq_ha_replication_group_name: ''
 
 
 ### Masked passwords

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -691,12 +691,50 @@ argument_specs:
                 description: "Whether to enable the message counters"
             activemq_message_counter_sample_period:
                 default: 10000
-                type: int
+                type: "int"
                 description: "The sample period (in ms) to use for message counters"
             activemq_message_counter_max_day_history:
                 default: 10
-                type: int
+                type: "int"
                 description: "How many days to keep message counter history"
+            activemq_ha_allow_failback:
+                default: true
+                type: "bool"
+                description: >
+                  Whether a server will automatically stop when a another places a request to take over
+                  its place. The use case is when a regular server stops and its backup takes over its
+                  duties, later the main server restarts and requests the server (the former backup) to
+                  stop operating
+            activemq_ha_failover_on_shutdown:
+                default: true
+                type: "bool"
+                description: "Will this backup server become active on a normal server shutdown"
+            activemq_ha_restart_backup:
+                default: false
+                type: "bool"
+                description: >
+                  Will this server, if a backup, restart once it has been stopped because of failback or
+                  scaling down
+            activemq_ha_check_for_active_server:
+                default: "{{ activemq_replication }}"
+                type: "bool"
+                description: >
+                  Whether to check the cluster for a (live) server using our own server ID when starting
+                  up. This option is only necessary for performing 'fail-back' on replicating
+                  servers.
+            activemq_ha_replication_cluster_name:
+                default: ""
+                type: "str"
+                description: >
+                  Name of the cluster configuration to use for replication. This setting is only necessary in
+                  case you configure multiple cluster connections. It is used by a replicating backups and by
+                  primary servers that may attempt fail-back
+            activemq_ha_replication_group_name:
+                default: ""
+                type: "str"
+                description: >
+                  With replication, if set, remote backup servers will only pair with primary servers with
+                  matching group-name
     systemd:
         options:
             activemq_version:

--- a/roles/activemq/templates/ha_policy.xml.j2
+++ b/roles/activemq/templates/ha_policy.xml.j2
@@ -29,14 +29,22 @@
           <{{ activemq_ha_role }}>
             <allow-failback>{{ activemq_ha_allow_failback }}</allow-failback>
             <restart-backup>{{ activemq_ha_restart_backup }}</restart-backup>
+{% if activemq_ha_replication_cluster_name | length > 0 %}
             <cluster-name>{{ activemq_ha_replication_cluster_name }}</cluster-name>
+{% endif %}
+{% if activemq_ha_replication_group_name | length > 0 %}
             <group-name>{{ activemq_ha_replication_group_name }}</group-name>
+{% endif %}
           </{{ activemq_ha_role }}>
 {% elif activemq_ha_role == 'master' or activemq_ha_role == 'primary' %}
           <{{ activemq_ha_role }}>
             <check-for-active-server>{{ activemq_ha_check_for_active_server }}</check-for-active-server>
+{% if activemq_ha_replication_cluster_name | length > 0 %}
             <cluster-name>{{ activemq_ha_replication_cluster_name }}</cluster-name>
+{% endif %}
+{% if activemq_ha_replication_group_name | length > 0 %}
             <group-name>{{ activemq_ha_replication_group_name }}</group-name>
+{% endif %}
           </{{ activemq_ha_role }}>
 {% endif %}
         </replication>

--- a/roles/activemq/templates/ha_policy.xml.j2
+++ b/roles/activemq/templates/ha_policy.xml.j2
@@ -13,12 +13,13 @@
         <shared-store>
 {% if activemq_ha_role == 'slave' or activemq_ha_role == 'backup' %}
           <{{ activemq_ha_role }}>
-            <allow-failback>true</allow-failback>
+            <allow-failback>{{ activemq_ha_allow_failback }}</allow-failback>
+            <restart-backup>{{ activemq_ha_restart_backup }}</restart-backup>
           </{{ activemq_ha_role }}>
-{% else %}
-          <master>
-            <failover-on-shutdown>true</failover-on-shutdown>
-          </master>
+{% elif activemq_ha_role == 'master' or activemq_ha_role == 'primary' %}
+          <{{ activemq_ha_role }}>
+            <failover-on-shutdown>{{ activemq_ha_failover_on_shutdown }}</failover-on-shutdown>
+          </{{ activemq_ha_role }}>
 {% endif %}
         </shared-store>
 {% endif %}
@@ -26,12 +27,17 @@
         <replication>
 {% if activemq_ha_role == 'slave' or activemq_ha_role == 'backup' or amq_broker_replicated %}
           <{{ activemq_ha_role }}>
-            <allow-failback>true</allow-failback>
+            <allow-failback>{{ activemq_ha_allow_failback }}</allow-failback>
+            <restart-backup>{{ activemq_ha_restart_backup }}</restart-backup>
+            <cluster-name>{{ activemq_ha_replication_cluster_name }}</cluster-name>
+            <group-name>{{ activemq_ha_replication_group_name }}</group-name>
           </{{ activemq_ha_role }}>
-{% else %}
-          <master>
-            <check-for-live-server>true</check-for-live-server>
-          </master>
+{% elif activemq_ha_role == 'master' or activemq_ha_role == 'primary' %}
+          <{{ activemq_ha_role }}>
+            <check-for-active-server>{{ activemq_ha_check_for_active_server }}</check-for-active-server>
+            <cluster-name>{{ activemq_ha_replication_cluster_name }}</cluster-name>
+            <group-name>{{ activemq_ha_replication_group_name }}</group-name>
+          </{{ activemq_ha_role }}>
 {% endif %}
         </replication>
 {% endif %}

--- a/roles/activemq/templates/ha_policy.xml.j2
+++ b/roles/activemq/templates/ha_policy.xml.j2
@@ -13,12 +13,12 @@
         <shared-store>
 {% if activemq_ha_role == 'slave' or activemq_ha_role == 'backup' %}
           <{{ activemq_ha_role }}>
-            <allow-failback>{{ activemq_ha_allow_failback }}</allow-failback>
-            <restart-backup>{{ activemq_ha_restart_backup }}</restart-backup>
+            <allow-failback>{{ activemq_ha_allow_failback | lower }}</allow-failback>
+            <restart-backup>{{ activemq_ha_restart_backup | lower }}</restart-backup>
           </{{ activemq_ha_role }}>
 {% elif activemq_ha_role == 'master' or activemq_ha_role == 'primary' %}
           <{{ activemq_ha_role }}>
-            <failover-on-shutdown>{{ activemq_ha_failover_on_shutdown }}</failover-on-shutdown>
+            <failover-on-shutdown>{{ activemq_ha_failover_on_shutdown | lower }}</failover-on-shutdown>
           </{{ activemq_ha_role }}>
 {% endif %}
         </shared-store>
@@ -27,8 +27,8 @@
         <replication>
 {% if activemq_ha_role == 'slave' or activemq_ha_role == 'backup' or amq_broker_replicated %}
           <{{ activemq_ha_role }}>
-            <allow-failback>{{ activemq_ha_allow_failback }}</allow-failback>
-            <restart-backup>{{ activemq_ha_restart_backup }}</restart-backup>
+            <allow-failback>{{ activemq_ha_allow_failback | lower }}</allow-failback>
+            <restart-backup>{{ activemq_ha_restart_backup | lower }}</restart-backup>
 {% if activemq_ha_replication_cluster_name | length > 0 %}
             <cluster-name>{{ activemq_ha_replication_cluster_name }}</cluster-name>
 {% endif %}
@@ -38,7 +38,7 @@
           </{{ activemq_ha_role }}>
 {% elif activemq_ha_role == 'master' or activemq_ha_role == 'primary' %}
           <{{ activemq_ha_role }}>
-            <check-for-active-server>{{ activemq_ha_check_for_active_server }}</check-for-active-server>
+            <check-for-active-server>{{ activemq_ha_check_for_active_server | lower }}</check-for-active-server>
 {% if activemq_ha_replication_cluster_name | length > 0 %}
             <cluster-name>{{ activemq_ha_replication_cluster_name }}</cluster-name>
 {% endif %}


### PR DESCRIPTION
New parameters that apply to shared store or replication HA policies:

| Variable | Description | Default |
|:---------|:------------|:--------|
|`activemq_ha_allow_failback`| Whether a server will automatically stop when another places a request to take over its place |`true` |
|`activemq_ha_failover_on_shutdown`| Will this backup server become active on a normal server shutdown  | `true` |
|`activemq_ha_restart_backup`| Will this server, if a backup, restart once it has been stopped because of failback or scaling down | `false` |
|`activemq_ha_check_for_active_server`| Whether to check the cluster for a live server using our own server ID when starting up. This option is only necessary for performing 'fail-back' on replicating servers | `false` |
|`activemq_ha_replication_cluster_name`| Name of the cluster configuration to use for replication. This setting is only necessary in case you configure multiple cluster connections | `""` |
|`activemq_ha_replication_group_name`| With replication, if set, remote backup servers will only pair with primary servers with matching group-name | `""` |

Fix #154 