### PR TITLE
Add wait_for configuration

### DIFF
--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -278,6 +278,9 @@ Sample divert:
 |`activemq_systemd_wait_for_log` | Whether systemd unit should wait for service to be up in logs | `True` when `activemq_ha_enabled` and `activemq_shared_storage` are both `True` |
 |`activemq_systemd_wait_for_timeout`| How long to wait for service to be alive (seconds) | `60` |
 |`activemq_systemd_wait_for_delay`| Activation delay for service systemd unit | `10` |
+|`activemq_systemd_wait_for_log_ha_string` | The string to match in the logs when `activemq_systemd_wait_for_log` is true and HA is enabled | `AMQ221109\|AMQ221001` |
+|`activemq_systemd_wait_for_log_string` | The string to match in the logs when `activemq_systemd_wait_for_log` is true and HA is not enabled | `AMQ221034` |
+|`activemq_systemd_wait_for_port_number`| The port number to wait for when `activemq_systemd_wait_for_port` is true | `{{ activemq_port }}` |
 |`activemq_ha_allow_failback`| Whether a server will automatically stop when another places a request to take over its place |`true` |
 |`activemq_ha_failover_on_shutdown`| Will this backup server become active on a normal server shutdown  | `true` |
 |`activemq_ha_restart_backup`| Will this server, if a backup, restart once it has been stopped because of failback or scaling down | `false` |

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -66,6 +66,9 @@ activemq_systemd_wait_for_port: "{{ activemq_ha_enabled and not activemq_shared_
 activemq_systemd_wait_for_log: "{{ activemq_ha_enabled and activemq_shared_storage }}"
 activemq_systemd_wait_for_timeout: 60
 activemq_systemd_wait_for_delay: 10
+activemq_systemd_wait_for_log_ha_string: 'AMQ221109\\\\|AMQ221001'
+activemq_systemd_wait_for_log_string: 'AMQ221034'
+activemq_systemd_wait_for_port_number: "{{ activemq_port }}"
 activemq_ha_role: live-only
 activemq_ha_allow_failback: true
 activemq_ha_failover_on_shutdown: true

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -735,6 +735,18 @@ argument_specs:
                 description: >
                   With replication, if set, remote backup servers will only pair with primary servers with
                   matching group-name
+            activemq_systemd_wait_for_log_ha_string:
+                default: 'AMQ221109\\\\|AMQ221001'
+                type: "str"
+                description: "The string to match in the logs when ctivemq_systemd_wait_for_log is true and HA is enabled"
+            activemq_systemd_wait_for_log_string:
+                default: 'AMQ221034'
+                type: "str"
+                description: "The string to match in the logs when ctivemq_systemd_wait_for_log is true and HA is not enabled"
+            activemq_systemd_wait_for_port_number:
+                default: "{{ activemq_port }}"
+                type: 'int'
+                description: "The port number to wait for when activemq_systemd_wait_for_port is true"
     systemd:
         options:
             activemq_version:
@@ -814,6 +826,18 @@ argument_specs:
                 description: "Artemis role for hawtio console access"
                 default: "amq"
                 type: "str"
+            activemq_systemd_wait_for_log_ha_string:
+                default: 'AMQ221109|AMQ221001'
+                type: "str"
+                description: "The string to match in the logs when ctivemq_systemd_wait_for_log is true and HA is enabled"
+            activemq_systemd_wait_for_log_string:
+                default: 'AMQ221034'
+                type: "str"
+                description: "The string to match in the logs when ctivemq_systemd_wait_for_log is true and HA is not enabled"
+            activemq_systemd_wait_for_port_number:
+                default: "{{ activemq_port }}"
+                type: 'int'
+                description: "The port number to wait for when activemq_systemd_wait_for_port is true"
     downstream:
         options:
             amq_broker_version:

--- a/roles/activemq/templates/amq_broker.service.j2
+++ b/roles/activemq/templates/amq_broker.service.j2
@@ -20,15 +20,13 @@ Restart = on-failure
 LimitNOFILE=102642
 TimeoutSec=600
 {% if activemq_systemd_wait_for_port %}
-ExecStartPost=/usr/bin/timeout {{ activemq_systemd_wait_for_timeout }} sh -c 'while ! ss -H -t -l -n sport = :{{ activemq_port }} | grep -q "^LISTEN.*:{{ activemq_port }}"; do sleep 1; done && /bin/sleep {{ activemq_systemd_wait_for_delay }}'
+ExecStartPost=/usr/bin/timeout {{ activemq_systemd_wait_for_timeout }} sh -c 'while ! ss -H -t -l -n sport = :{{ activemq_systemd_wait_for_port_number }} | grep -q "^LISTEN.*:{{ activemq_systemd_wait_for_port_number }}"; do sleep 1; done && /bin/sleep {{ activemq_systemd_wait_for_delay }}'
 {% endif %}
 {% if activemq_systemd_wait_for_log %}
-{% if activemq_ha_enabled and (activemq_ha_role == 'slave' or activemq_ha_role == 'backup') %}
-ExecStartPost=/usr/bin/timeout {{ activemq_systemd_wait_for_timeout }} sh -c 'tail -n 15 -f {{ activemq.instance_home }}/log/artemis.log | sed "/AMQ221109/ q" && /bin/sleep {{ activemq_systemd_wait_for_delay }}'
-{% elif activemq_ha_enabled and (activemq_ha_role == 'master' or activemq_ha_role == 'primary') %}
-ExecStartPost=/usr/bin/timeout {{ activemq_systemd_wait_for_timeout }} sh -c 'tail -n 15 -f {{ activemq.instance_home }}/log/artemis.log | sed "/AMQ221001/ q" && /bin/sleep {{ activemq_systemd_wait_for_delay }}'
+{% if activemq_ha_enabled %}
+ExecStartPost=/usr/bin/timeout {{ activemq_systemd_wait_for_timeout }} sh -c 'tail -n 15 -f {{ activemq.instance_home }}/log/artemis.log | sed "/{{ activemq_systemd_wait_for_log_ha_string }}/ q" && /bin/sleep {{ activemq_systemd_wait_for_delay }}'
 {% else %}
-ExecStartPost=/usr/bin/timeout {{ activemq_systemd_wait_for_timeout }} sh -c 'tail -n 15 -f {{ activemq.instance_home }}/log/artemis.log | sed "/AMQ221034/ q" && /bin/sleep {{ activemq_systemd_wait_for_delay }}'
+ExecStartPost=/usr/bin/timeout {{ activemq_systemd_wait_for_timeout }} sh -c 'tail -n 15 -f {{ activemq.instance_home }}/log/artemis.log | sed "/{{ activemq_systemd_wait_for_log_string }}/ q" && /bin/sleep {{ activemq_systemd_wait_for_delay }}'
 {% endif %}
 {% endif %}
 


### PR DESCRIPTION
Make the port number and the matched string configurable for activemq_systemd_wait_for_xxx : 

| Variable | Description | Default |
|:---------|:------------|:--------|
|`activemq_systemd_wait_for_log_ha_string` | The string to match in the logs when `activemq_systemd_wait_for_log` is true and HA is enabled | `AMQ221109\|AMQ221001` |
|`activemq_systemd_wait_for_log_string` | The string to match in the logs when `activemq_systemd_wait_for_log` is true and HA is not enabled | `AMQ221034` |
|`activemq_systemd_wait_for_port_number`| The port number to wait for when `activemq_systemd_wait_for_port` is true | `{{ activemq_port }}` |

Also, the matched string in case of HA is not differentiated between primary and backup roles.