### PR TITLE
Use bind_address instead of hostname for console binding

### DIFF
--- a/roles/activemq/tasks/configure_files.yml
+++ b/roles/activemq/tasks/configure_files.yml
@@ -38,7 +38,7 @@
     path: "{{ activemq.instance_home }}/etc/bootstrap.xml"
     xpath: '/b:broker/b:web/b:binding'
     attribute: uri
-    value: "http{{ 's' if activemq_tls_enabled else '' }}://{{ activemq_host }}:{{ activemq_http_port }}"
+    value: "http{{ 's' if activemq_tls_enabled else '' }}://{{ activemq_bind_address }}:{{ activemq_http_port }}"
     namespaces:
       b: http://activemq.apache.org/schema
   notify:


### PR DESCRIPTION
Fix a regression caused by binding console to hostname in bootstrap.xml
Fix #157 