### PR TITLE
Add more journal configs

### DIFF
--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -134,6 +134,9 @@ Role Defaults
 |`activemq_journal_file_size`| The size (in bytes) of each journal file | `10M` |
 |`activemq_journal_buffer_timeout`| The Flush timeout for the journal buffer | `500000` if 'ASYNCIO' else `3333333` |
 |`activemq_journal_max_io`| The maximum number of write requests that can be in the ASYNCIO queue at any one time | `4096` if 'ASYNCIO' else `1` |
+|`activemq_journal_buffer_size`| The size of the internal buffer on the journal in KB  | `490KiB` |
+|`activemq_disk_scan_period`| The interval where the disk is scanned for percentual usage | `5000` |
+|`activemq_max_disk_usage`| The max percentage of data we should use from disks. The System will block while the disk is full | `96` |
 |`activemq_db_enabled`| Whether to enable JDBC persistence | `False` |
 |`activemq_db_jdbc_url`| The full JDBC connection URL for your database server | `jdbc:derby:target/derby/database-store;create=true` |
 |`activemq_db_bindings_table`| The name of the table in which bindings data will be persisted | `BINDINGS_TABLE` |

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -126,6 +126,9 @@ activemq_journal_pool_files: 10
 activemq_journal_device_block_size: 4096
 activemq_journal_file_size: 10M
 activemq_journal_buffer_timeout: "{{ 500000 if activemq_journal_type == 'ASYNCIO' else 3333333 }}"
+activemq_journal_buffer_size: '490KiB'
+activemq_disk_scan_period: 5000
+activemq_max_disk_usage: 96
 activemq_journal_max_io: "{{ 4096 if activemq_journal_type == 'ASYNCIO' else 1 }}"
 # message Full Policy configured
 activemq_global_max_messages: -1

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -755,6 +755,18 @@ argument_specs:
                 default: []
                 type: 'list'
                 description: "The list of broker-plugins configurations (dict: { class_name, properties(dict) })"
+            activemq_journal_buffer_size:
+                description: "The size of the internal buffer on the journal in KB"
+                default: '490KiB'
+                type: 'str'
+            activemq_disk_scan_period:
+                description: "The interval where the disk is scanned for percentual usage."
+                default: 5000
+                type: 'int'
+            activemq_max_disk_usage:
+                description: "The max percentage of data we should use from disks. The System will block while the disk is full."
+                default: 96
+                type: 'int'
     systemd:
         options:
             activemq_version:

--- a/roles/activemq/vars/main.yml
+++ b/roles/activemq/vars/main.yml
@@ -46,6 +46,9 @@ activemq_core_configuration_list:
   - journal_file_size
   - journal_buffer_timeout
   - journal_max_io
+  - journal_buffer_size
+  - disk_scan_period
+  - max_disk_usage
   - configuration_file_refresh_period
   - global_max_messages
   - global_max_size


### PR DESCRIPTION
New parameters:

| Variable | Description | Default |
|:---------|:------------|:--------|
|`activemq_journal_buffer_size`| The size of the internal buffer on the journal in KB  | `490KiB` |
|`activemq_disk_scan_period`| The interval where the disk is scanned for percentual usage | `5000` |
|`activemq_max_disk_usage`| The max percentage of data we should use from disks. The System will block while the disk is full | `96` |