### PR TITLE
Fix condition for transferring key/trust store

### DIFF
--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -152,7 +152,7 @@ Role Defaults
 |`activemq_critical_analyzer`| Should the broker detect dead locks and other issues | `true` |
 |`activemq_critical_analyzer_timeout`| Timeout used to do the critical analysis (milliseconds) | `120000` |
 |`activemq_critical_analyzer_check_period`| Time used to check the response times (milliseconds) | `60000` |
-|`activemq_critical_analyzer_policy`| Should the server log, be halted or shutdown upon failures (one of LOG, HALT, SHUTDOWN) | `HALT` |
+|`activemq_critical_analyzer_policy`| Should the server log, be halted or shutdown upon failures (one of LOG, HALT, SHUTDOWN) | `LOG` |
 
 
 #### Acceptors / connectors

--- a/roles/activemq/tasks/keystores.yml
+++ b/roles/activemq/tasks/keystores.yml
@@ -7,7 +7,7 @@
     group: "{{ activemq_service_group }}"
     mode: '0400'
   when:
-    - activemq_tls_truststore_path is defined
+    - activemq_tls_truststore_path | default('', true) | length > 0
     - activemq_tls_enabled
   become: true
 
@@ -19,6 +19,6 @@
     group: "{{ activemq_service_group }}"
     mode: '0400'
   when:
-    - activemq_tls_keystore_path is defined
+    - activemq_tls_keystore_path | default('', true) | length > 0
     - activemq_tls_enabled
   become: true

--- a/roles/activemq/templates/amq_broker.sysconfig.j2
+++ b/roles/activemq/templates/amq_broker.sysconfig.j2
@@ -1,5 +1,5 @@
 # {{ ansible_managed }}
-JAVA_ARGS='{{ activemq_java_opts }} {{ activemq_logger_opts }} {{ activemq_jmx_opts }} {{ activemq_properties_opts }}'
+JAVA_ARGS="{{ activemq_java_opts }} {{ activemq_logger_opts }} {{ activemq_jmx_opts }} {{ activemq_properties_opts }}"
 JAVA_HOME={{ activemq_java_home  | default(activemq_rpm_java_home, true) }}
 HAWTIO_ROLE='{{ activemq_hawtio_role }}'
 ARTEMIS_INSTANCE_URI='file:{{ activemq.instance_home }}/'


### PR DESCRIPTION
Fix the condition for transferring TLS stores, which would end in an error for paths defined as empty string.

This change also inverts nesting of single and double quotes in the sysconfig file for JAVA_ARGS: this allows to embed commands in it, like as follows:

    -XX:HeapDumpPath=/varr/log/amq-broker/amq-broker_$(date "+%Y%m%d_%H%M%S").hprof 