### PR TITLE
New `activemq_console_bind_url` parameter

### DIFF
--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -63,8 +63,8 @@ Role Defaults
 |`activemq_bind_address`| Service bind address | `0.0.0.0` |
 |`activemq_host`| Service hostname | `localhost` |
 |`activemq_http_port`| Service http port serving console and REST api | `8161` |
-|`activemq_jolokia_url`| URL for jolokia REST api | `http://{{ activemq_host }}:{{ activemq_http_port }}/console/jolokia` |
-|`activemq_console_url`| URL for console service | `http://{{ activemq_host }}:{{ activemq_http_port }}/console/` |
+|`activemq_jolokia_url`| URL for jolokia REST api | `{{ activemq_console_url }}/jolokia` |
+|`activemq_console_url`| URL for console service | `{{ activemq_console_bind_url }}/console/` |
 |`activemq_jvm_package`| RPM package to install for the service | `java-17-openjdk-headless` |
 |`activemq_java_opts`| Additional JVM options for the service | `-Xms512M -Xmx2G [...]` |
 |`activemq_port`| Main port for the broker instance | `61616` |
@@ -87,6 +87,7 @@ Role Defaults
 |`activemq_mask_password_iterations`| Number of iterations for masking password, will be passed to custom codec | `1024` |
 |`activemq_properties_file`| Properties file to allow updates and additions to the broker configuration after any xml has been parsed | `""` |
 |`activemq_modular_configuration`| Whether or not to enable XInclude modular configuration of broker.xml | `false` |
+|`activemq_console_bind_url`| The value to use in bootstrap.xml for web console binding | `http{{ 's' if activemq_tls_enabled else '' }}://{{ activemq_bind_address }}:{{ activemq_http_port }}` |
 
 
 #### LDAP authN/authZ

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -26,8 +26,9 @@ activemq_configure_firewalld: false
 activemq_bind_address: 0.0.0.0
 activemq_host: localhost
 activemq_http_port: 8161
-activemq_jolokia_url: "http://{{ activemq_host }}:{{ activemq_http_port }}/console/jolokia"
-activemq_console_url: "http://{{ activemq_host }}:{{ activemq_http_port }}/console/"
+activemq_console_bind_url: "http{{ 's' if activemq_tls_enabled else '' }}://{{ activemq_bind_address }}:{{ activemq_http_port }}"
+activemq_console_url: "{{ activemq_console_bind_url }}/console/"
+activemq_jolokia_url: "{{ activemq_console_url }}jolokia"
 activemq_configuration_file_refresh_period: 5000
 activemq_jvm_package: java-17-openjdk-headless
 activemq_java_home:

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -783,6 +783,10 @@ argument_specs:
                 description: "Should the server log, be halted or shutdown upon failures (one of LOG, HALT, SHUTDOWN)"
                 default: 'LOG'
                 type: 'str'
+            activemq_console_bind_url:
+                description: "The value to use in bootstrap.xml for web console binding"
+                default: "http{{ 's' if activemq_tls_enabled else '' }}://{{ activemq_bind_address }}:{{ activemq_http_port }}"
+                type: 'str'
     systemd:
         options:
             activemq_version:

--- a/roles/activemq/tasks/configure_files.yml
+++ b/roles/activemq/tasks/configure_files.yml
@@ -38,7 +38,7 @@
     path: "{{ activemq.instance_home }}/etc/bootstrap.xml"
     xpath: '/b:broker/b:web/b:binding'
     attribute: uri
-    value: "http{{ 's' if activemq_tls_enabled else '' }}://{{ activemq_bind_address }}:{{ activemq_http_port }}"
+    value: "{{ activemq_console_bind_url }}"
     namespaces:
       b: http://activemq.apache.org/schema
   notify:


### PR DESCRIPTION
The parameter allows to set an arbitrary value in the web console binding setting in `bootstrap.xml`.

```xml
   <web path="web" rootRedirectLocation="console">
       <binding name="artemis" uri="{{ activemq_console_bind_url }}">
```

`activemq_jolokia_url` and `activemq_console_url` are now re-defaulted to use such value.

| Variable | Description | Default |
|:---------|:------------|:--------|
|`activemq_jolokia_url`| URL for jolokia REST api | `{{ activemq_console_url }}/jolokia` |
|`activemq_console_url`| URL for console service | `{{ activemq_console_bind_url }}/console/` |
|`activemq_console_bind_url`| The value to use in bootstrap.xml for web console binding | `http{{ 's' if activemq_tls_enabled else '' }}://{{ activemq_bind_address }}:{{ activemq_http_port }}` |

No change to current configuration is needed, all default values remain the same.