### PR TITLE
Add `activemq_systemd_expand_environment` parameter

### DIFF
--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -302,6 +302,7 @@ Sample divert:
 |`activemq_ha_check_for_active_server`| Whether to check the cluster for a live server using our own server ID when starting up. This option is only necessary for performing 'fail-back' on replicating servers | `false` |
 |`activemq_ha_replication_cluster_name`| Name of the cluster configuration to use for replication. This setting is only necessary in case you configure multiple cluster connections | `""` |
 |`activemq_ha_replication_group_name`| With replication, if set, remote backup servers will only pair with primary servers with matching group-name | `""` |
+|`activemq_systemd_expand_environment` | Whether or not to expand the environment in the sysconfig file. If true, environment file is sourced and the activemq process is started in a shell | `false` |
 
 
 #### Multi-site fault-tolerance (AMQP broker connections)

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -71,6 +71,7 @@ activemq_systemd_wait_for_delay: 10
 activemq_systemd_wait_for_log_ha_string: 'AMQ221109\\\\|AMQ221001'
 activemq_systemd_wait_for_log_string: 'AMQ221034'
 activemq_systemd_wait_for_port_number: "{{ activemq_port }}"
+activemq_systemd_expand_environment: false
 activemq_ha_role: live-only
 activemq_ha_allow_failback: true
 activemq_ha_failover_on_shutdown: true

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -787,6 +787,12 @@ argument_specs:
                 description: "The value to use in bootstrap.xml for web console binding"
                 default: "http{{ 's' if activemq_tls_enabled else '' }}://{{ activemq_bind_address }}:{{ activemq_http_port }}"
                 type: 'str'
+            activemq_systemd_expand_environment:
+                default: false
+                description: >
+                  Whether or not to expand the environment in the sysconfig file. If true, environment file is sourced and the \
+                  activemq process is started in a shell
+                type: 'str'
     systemd:
         options:
             activemq_version:

--- a/roles/activemq/templates/amq_broker.service.j2
+++ b/roles/activemq/templates/amq_broker.service.j2
@@ -12,7 +12,7 @@ Group={{ activemq_service_group }}
 Type=forking
 EnvironmentFile=-/etc/sysconfig/{{ activemq.instance_name }}
 PIDFile={{ activemq.instance_home }}/{{ activemq_service_pidfile }}
-if {% activemq_systemd_expand_environment %}
+{% if activemq_systemd_expand_environment %}
 ExecStart=/bin/bash -ac '. /etc/sysconfig/{{ activemq.instance_name }} ; exec {{ activemq.instance_home }}/bin/artemis-service start'
 {% else %}
 ExecStart={{ activemq.instance_home }}/bin/artemis-service start

--- a/roles/activemq/templates/amq_broker.service.j2
+++ b/roles/activemq/templates/amq_broker.service.j2
@@ -12,7 +12,11 @@ Group={{ activemq_service_group }}
 Type=forking
 EnvironmentFile=-/etc/sysconfig/{{ activemq.instance_name }}
 PIDFile={{ activemq.instance_home }}/{{ activemq_service_pidfile }}
+if {% activemq_systemd_expand_environment %}
+ExecStart=/bin/bash -ac '. /etc/sysconfig/{{ activemq.instance_name }} ; exec {{ activemq.instance_home }}/bin/artemis-service start'
+{% else %}
 ExecStart={{ activemq.instance_home }}/bin/artemis-service start
+{% endif %}
 ExecStop={{ activemq.instance_home }}/bin/artemis-service stop
 SuccessExitStatus = 0 143
 RestartSec = 120


### PR DESCRIPTION
When the new parameter is set to `true`:

| Variable | Description | Default |
|:---------|:------------|:--------|
|`activemq_systemd_expand_environment` | Whether or not to expand the environment in the sysconfig file. If true, environment file is sourced and the activemq process is started in a shell | `false` |

the systemd unit template is changed to run the activemq process in a shell, sourcing the sysconfig environment file just before exection. This allows to use shell expansions in the environment file.

Examples:

```yaml
activemq_systemd_expand_environment: true
activemq_java_opts_mem: '-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/amq_$(date "+%Y%m%d_%H%M%S").hprof'
```