### PR TITLE
Add `web_origin` parameter to `activemq_facts` module

### DIFF
--- a/plugins/modules/activemq_facts.py
+++ b/plugins/modules/activemq_facts.py
@@ -64,6 +64,12 @@ options:
             - Verify TLS certificates when using https.
         type: bool
         default: true
+    web_origin:
+        description:
+            - The value to use in the Origin header for the http request
+        type: str
+        required: false
+        default: http://0.0.0.0
     connection_timeout:
         description:
             - Controls the HTTP connections timeout period in seconds to jolokia API.
@@ -113,6 +119,7 @@ class JolokiaService(object):
         self.baseurl = self.module.params.get('base_url')
         self.broker = self.module.params.get('broker_name')
         self.validate_certs = self.module.params.get('validate_certs')
+        self.web_origin = self.module.params.get('web_origin')
         self.connection_timeout = self.module.params.get('connection_timeout')
         self.auth_username = self.module.params.get('auth_username')
         self.auth_password = self.module.params.get('auth_password')
@@ -130,7 +137,7 @@ class JolokiaService(object):
 
         restheaders = {}
         restheaders["Authorization"] = basic_auth_header(self.auth_username, self.auth_password)
-        restheaders['Origin'] = self.baseurl if 'localhost' not in self.baseurl else 'https://0.0.0.0'
+        restheaders["Origin"] = self.web_origin
 
         try:
             return json.loads(to_native(open_url(jolokia_url, method='GET',
@@ -164,6 +171,7 @@ def amq_argument_spec():
         auth_username=dict(type='str', aliases=['username'], required=True),
         auth_password=dict(type='str', aliases=['password'], required=True, no_log=True),
         validate_certs=dict(type='bool', default=True),
+        web_origin=dict(type='str', required=False, default="http://0.0.0.0", no_log=False),
         connection_timeout=dict(type='int', default=10)
     )
 


### PR DESCRIPTION
Instead of guessing the 'Origin' header value from the `base_url`, add a parameter for it. Defaults to `http:/0.0.0.0`.

```yaml
- name: Populate activemq facts
  middleware_automation.amq.activemq_facts:
    base_url: 'https://internal.access.jolokia'
    auth_username: username
    auth_password: password
    web_origin: 'https://somesite.somedomain'
```

Corresponding CORS setting in the install role are:

| Variable | Description | Default |
|:---------|:------------|:--------|
|`activemq_cors_allow_origin`| List of CORS allow origin setting for jolokia | `[ *://0.0.0.0* ]` |
|`activemq_cors_strict_checking`| Whether to enforce strict checking for CORS | `True` |
