### PR TITLE
Allow to explicitly list `cluster-connections`

### DIFF
--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -287,7 +287,8 @@ Sample divert:
 |`activemq_ha_role` | Instance role for high availability | `live-only` |
 |`activemq_replication`| Enables replication | `False` |
 |`activemq_replicated`| Designate instance as replicated node | `False` |
-|`activemq_cluster_discovery` | Cluster discovery: [`jgroups` (shared file ping), `multicast` (UDP), `static` (node list)] | `static` |
+|`activemq_cluster_discovery` | Cluster discovery: [`jgroups` (shared file ping), `multicast` (UDP), `static` (node list), `provided` (use `activemq_cluster_connections`)] | `static` |
+|`activemq_cluster_connections`| The list of cluster connection names from the connectors list, when `activemq_cluster_discovery` = provided | `[]` |
 |`activemq_cluster_iface` | The NIC name to be used for cluster IPv4 addresses (ie. 'eth0') | `default_ipv4` |
 |`activemq_systemd_wait_for_port` | Whether systemd unit should wait for activemq port before returning | `True` when `activemq_ha_enabled` is `True` and `activemq_shared_storage` is `False` |
 |`activemq_systemd_wait_for_log` | Whether systemd unit should wait for service to be up in logs | `True` when `activemq_ha_enabled` and `activemq_shared_storage` are both `True` |
@@ -296,13 +297,15 @@ Sample divert:
 |`activemq_systemd_wait_for_log_ha_string` | The string to match in the logs when `activemq_systemd_wait_for_log` is true and HA is enabled | `AMQ221109\|AMQ221001` |
 |`activemq_systemd_wait_for_log_string` | The string to match in the logs when `activemq_systemd_wait_for_log` is true and HA is not enabled | `AMQ221034` |
 |`activemq_systemd_wait_for_port_number`| The port number to wait for when `activemq_systemd_wait_for_port` is true | `{{ activemq_port }}` |
+|`activemq_systemd_expand_environment` | Whether or not to expand the environment in the sysconfig file. If true, environment file is sourced and the activemq process is started in a shell | `false` |
 |`activemq_ha_allow_failback`| Whether a server will automatically stop when another places a request to take over its place |`true` |
 |`activemq_ha_failover_on_shutdown`| Will this backup server become active on a normal server shutdown  | `true` |
 |`activemq_ha_restart_backup`| Will this server, if a backup, restart once it has been stopped because of failback or scaling down | `false` |
 |`activemq_ha_check_for_active_server`| Whether to check the cluster for a live server using our own server ID when starting up. This option is only necessary for performing 'fail-back' on replicating servers | `false` |
 |`activemq_ha_replication_cluster_name`| Name of the cluster configuration to use for replication. This setting is only necessary in case you configure multiple cluster connections | `""` |
 |`activemq_ha_replication_group_name`| With replication, if set, remote backup servers will only pair with primary servers with matching group-name | `""` |
-|`activemq_systemd_expand_environment` | Whether or not to expand the environment in the sysconfig file. If true, environment file is sourced and the activemq process is started in a shell | `false` |
+|`activemq_ha_vote_on_replication_failure`| Whether this broker should vote to remain active if replication is lost. Only valid for quorum voting. | `false` |
+|`activemq_ha_quorum_size`| The quorum size used for voting after replication loss, -1 means use the current cluster size. Only valid for quorum voting | `-1` |
 
 
 #### Multi-site fault-tolerance (AMQP broker connections)

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -58,12 +58,15 @@ activemq_ha_enabled: false
 activemq_cluster_user: amq-cluster-user
 activemq_cluster_pass: amq-cluster-pass
 activemq_cluster_maxhops: 1
-activemq_cluster_lb_policy: ON_DEMAND
+activemq_cluster_lb_policy: 'ON_DEMAND'
 activemq_cluster_iface: default_ipv4
 activemq_replication: false
 activemq_replicated: false
-# cluster discovery: ['jgroups' for shared file ping, 'multicast' for UDP multicast, 'static' for static declaration]
+## cluster discovery: >
+# 'jgroups' for shared file ping, 'multicast' for UDP multicast
+# 'static' for static declaration + ansible_play_hosts, 'provided' for using activemq_cluster_connections only
 activemq_cluster_discovery: static
+activemq_cluster_connections: []
 activemq_systemd_wait_for_port: "{{ activemq_ha_enabled and not activemq_shared_storage }}"
 activemq_systemd_wait_for_log: "{{ activemq_ha_enabled and activemq_shared_storage }}"
 activemq_systemd_wait_for_timeout: 60
@@ -79,7 +82,8 @@ activemq_ha_restart_backup: false
 activemq_ha_check_for_active_server: "{{ activemq_replication }}"
 activemq_ha_replication_cluster_name: ''
 activemq_ha_replication_group_name: ''
-
+activemq_ha_vote_on_replication_failure: false
+activemq_ha_quorum_size: -1
 
 ### Masked passwords
 activemq_password_codec: 'org.apache.activemq.artemis.utils.DefaultSensitiveStringCodec'

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -164,8 +164,12 @@ argument_specs:
                 type: "str"
             activemq_cluster_discovery:
                 default: "static"
-                description: "Cluster discovery: ['jgroups' for shared file ping, 'multicast' for UDP multicast, 'static' for static declaration]"
+                description: "Cluster discovery: ['jgroups' for shared file ping, 'multicast' for UDP multicast, 'static' for static declaration, 'provided']"
                 type: "str"
+            activemq_cluster_connections:
+                description: "The list of cluster connection names from the connectors list, when activemq_cluster_discovery = provided"
+                default: []
+                type: "list"
             activemq_cluster_iface:
                 default: "default_ipv4"
                 description: "The NIC name to be used for cluster IPv4 addresses (ie. 'eth0')."
@@ -735,6 +739,14 @@ argument_specs:
                 description: >
                   With replication, if set, remote backup servers will only pair with primary servers with
                   matching group-name
+            activemq_ha_vote_on_replication_failure:
+                description: "Whether this broker should vote to remain active if replication is lost. Only valid for quorum voting."
+                default: false
+                type: 'bool'
+            activemq_ha_quorum_size:
+                description: "The quorum size used for voting after replication loss, -1 means use the current cluster size. Only valid for quorum voting"
+                default: -1
+                type: 'int'
             activemq_systemd_wait_for_log_ha_string:
                 default: 'AMQ221109\\\\|AMQ221001'
                 type: "str"

--- a/roles/activemq/tasks/connectors.yml
+++ b/roles/activemq/tasks/connectors.yml
@@ -30,12 +30,14 @@
 
 - name: Configure static cluster
   when:
-    - activemq_cluster_discovery == 'static'
+    - activemq_cluster_discovery == 'static' or activemq_cluster_discovery == 'provided'
     - activemq_ha_enabled
   block:
     - name: Create cluster connections configuration string
       ansible.builtin.set_fact:
         cluster_connections: "{{ lookup('template', 'cluster_connections.broker.xml.j2') }}"
+      vars:
+        connector_names: "{{ activemq_acceptors | default([]) | map(attribute='name') }}"
 
     - name: Create cluster connections in broker.xml
       middleware_automation.common.xml:

--- a/roles/activemq/tasks/main.yml
+++ b/roles/activemq/tasks/main.yml
@@ -25,6 +25,13 @@
     - activemq_ha_enabled
     - activemq_cluster_discovery == "static"
 
+- name: Create broker cluster node members
+  ansible.builtin.set_fact:
+    activemq_cluster_nodes: "{{ activemq_cluster_connections }}"
+  when:
+    - activemq_ha_enabled
+    - activemq_cluster_discovery == "provided"
+
 - name: Validate broker configuration
   ansible.builtin.include_tasks: validate_config.yml
   when: activemq_config_override_template == ''

--- a/roles/activemq/templates/cluster_connections.broker.xml.j2
+++ b/roles/activemq/templates/cluster_connections.broker.xml.j2
@@ -1,8 +1,20 @@
-         <cluster-connection name="{{ activemq_service_name }}">
+         <cluster-connection name="CL{{ activemq_instance_name }}">
+{% if activemq_cluster_discovery == 'static' %}
             <connector-ref>{% for param in activemq_connectors %}{% if param.address == 'localhost' %}{{ param.name }}{% endif %}{% endfor %}</connector-ref>
+{% elif activemq_cluster_discovery == 'provided' %}
+{% for param in merged_connectors %}
+{% if param.name in connector_names %}
+            <connector-ref>{{ param.name }}</connector-ref>
+{% endif %}
+{% endfor %}
+{% endif %}
             <message-load-balancing>{{ activemq_cluster_lb_policy }}</message-load-balancing>
             <max-hops>{{ activemq_cluster_maxhops }}</max-hops>
             <static-connectors>
-               {% for param in merged_connectors %}{% if param.address != 'localhost' %}<connector-ref>{{ param.name }}</connector-ref>{% endif %}{% endfor %}
+{% for param in merged_connectors %}
+{% if param.address != 'localhost' and not param.name in connector_names %}
+               <connector-ref>{{ param.name }}</connector-ref>
+{% endif %}
+{% endfor %}
             </static-connectors>
          </cluster-connection>

--- a/roles/activemq/templates/ha_policy.xml.j2
+++ b/roles/activemq/templates/ha_policy.xml.j2
@@ -29,6 +29,7 @@
           <{{ activemq_ha_role }}>
             <allow-failback>{{ activemq_ha_allow_failback | lower }}</allow-failback>
             <restart-backup>{{ activemq_ha_restart_backup | lower }}</restart-backup>
+            <quorum-size>{{ activemq_ha_quorum_size }}</quorum-size>
 {% if activemq_ha_replication_cluster_name | length > 0 %}
             <cluster-name>{{ activemq_ha_replication_cluster_name }}</cluster-name>
 {% endif %}
@@ -39,6 +40,8 @@
 {% elif activemq_ha_role == 'master' or activemq_ha_role == 'primary' %}
           <{{ activemq_ha_role }}>
             <check-for-active-server>{{ activemq_ha_check_for_active_server | lower }}</check-for-active-server>
+            <quorum-size>{{ activemq_ha_quorum_size }}</quorum-size>
+            <vote-on-replication-failure>{{ activemq_ha_vote_on_replication_failure | lower }}</vote-on-replication-failure>
 {% if activemq_ha_replication_cluster_name | length > 0 %}
             <cluster-name>{{ activemq_ha_replication_cluster_name }}</cluster-name>
 {% endif %}


### PR DESCRIPTION
Add a new choice in `activemq_cluster_discovery`: `provided`, which leverages the new `activemq_cluster_connections` parameter to build the broker cluster-connections reusing the already defined `activemq_connectors` names.

| Variable | Description | Default |
|:---------|:------------|:--------|
|`activemq_cluster_discovery` | Cluster discovery: [`jgroups` (shared file ping), `multicast` (UDP), `static` (node list), `provided` (use `activemq_cluster_connections`)] | `static` |
|`activemq_cluster_connections`| The list of cluster connection names from the connectors list, when `activemq_cluster_discovery` = provided | `[]` |

When setting the new `provided` value, it is possible to define:

```yaml
activemq_connectors:
  - name: master-AMQ01
    scheme: tcp
    address: amq01-primary.domain.tld
    port: 61321
  - name: slave-AMQ01
    scheme: tcp
    address: amq01-backup.domain.tld
    port: 61321
  - name: master-AMQ02
    scheme: tcp
    address: amq02-primary.domain.tld
    port: 61322
  - name: slave-AMQ02
    scheme: tcp
    address: amq02-primary.domain.tld
    port: 61322
  - name: master-AMQ03
    scheme: tcp
    address: amq03-primary.domain.tld
    port: 61323
  - name: slave-AMQ03
    scheme: tcp
    address: amq03-primary.domain.tld
    port: 61323
```

and then decoratively list the connector-refs as:

```yaml
activemq_cluster_discovery: provided
activemq_cluster_connections:
  - name: master-AMQ01
  - name: slave-AMQ01
  - name: master-AMQ02
  - name: slave-AMQ02
  - name: master-AMQ03
  - name: slave-AMQ03
```

Note: the first defined cluster connection is important when replicating with more that one connector, and `check-for-active-server` is enabled. See "cluster-name" documentation under: https://activemq.apache.org/components/artemis/documentation/latest/ha.html#additional-parameters-4 