### PR TITLE
Parameters for `activemq_addresses` as a dictionary

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -70,6 +70,8 @@
       - name: DLQ
         anycast:
           - name: DLQ
+            parameters:
+              durable: True
       - name: ExpiryQueue
         anycast:
           - name: ExpiryQueue
@@ -78,6 +80,9 @@
       - name: client123.pubsub
         multicast:
           - name: client123.pubsub.foo
+            parameters:
+              max_consumers: 1
+              delay_before_dispatch: 3
     activemq_broker_plugins:
       - class_name: org.apache.activemq.artemis.core.server.plugin.impl.LoggingActiveMQServerPlugin
         properties:

--- a/molecule/replication/converge.yml
+++ b/molecule/replication/converge.yml
@@ -45,6 +45,8 @@
       - name: DLQ
         anycast:
           - name: DLQ
+            parameters:
+              durable: True
       - name: ExpiryQueue
         anycast:
           - name: ExpiryQueue
@@ -54,6 +56,9 @@
       - name: b.test
         anycast:
           - name: b.test
+            parameters:
+              max_consumers: 1
+              delay_before_dispatch: 3
     activemq_diverts:
       - name: TESTDIVERT
         address: queue.in

--- a/roles/activemq/templates/addresses.broker.xml.j2
+++ b/roles/activemq/templates/addresses.broker.xml.j2
@@ -3,7 +3,7 @@
          <anycast>
 {% for queue in address['anycast'] %}
            <queue name="{{ queue.name }}"
-{% for param in lookup('ansible.builtin.dict', address.parameters, wantlist=true) %}
+{% for param in lookup('ansible.builtin.dict', queue.parameters, wantlist=true) %}
 {% if param.key not in ['durable','filter'] %}
             {{ param.key | replace('_','-') }}="{% if param.value is number %}{{ param.value | string | lower }}{% else %}{{ param.value }}{% endif %} }}"
 {% endif %}
@@ -18,7 +18,7 @@
          <multicast>
 {% for queue in address['multicast'] %}
            <queue name="{{ queue.name }}"
-{% for param in lookup('ansible.builtin.dict', address.parameters, wantlist=true) %}
+{% for param in lookup('ansible.builtin.dict', queue.parameters, wantlist=true) %}
 {% if param.key not in ['durable','filter'] %}
             {{ param.key | replace('_','-') }}="{% if param.value is number %}{{ param.value | string | lower }}{% else %}{{ param.value }}{% endif %} }}"
 {% endif %}

--- a/roles/activemq/templates/addresses.broker.xml.j2
+++ b/roles/activemq/templates/addresses.broker.xml.j2
@@ -1,28 +1,33 @@
        <address name="{{ address.name }}">
-{% if address['anycast'] is defined %}         <anycast>
+{% if address['anycast'] is defined %}
+         <anycast>
 {% for queue in address['anycast'] %}
-         <queue name="{{ queue.name }}"
-                max-consumers="{{ queue['max_consumers'] | default('-1') }}"
-                exclusive="{{ queue['exclusive'] | default('false') | lower }}"
-                consumers-before-dispatch="{{ queue['consumers_before_dispatch'] | default('0') }}"
-                delay-before-dispatch="{{ queue['delay_before_dispatch'] | default('-1') }}">
+           <queue name="{{ queue.name }}"
+{% for param in lookup('ansible.builtin.dict', address.parameters, wantlist=true) %}
+{% if param.key not in ['durable','filter'] }%
+            {{ param.key | replace('_','-') }}="{% if param.value is number %}{{ param.value | string | lower }}{% else %}{{ param.value }}{% endif %} }}"
+{% endif %}
+{% endfor %}
 {% if queue['filter'] is defined %}           <filter string="{{ queue['filter'] }}"/>{% endif %}
-           <durable>{{ queue['durable'] | default('true') | lower }}</durable>
-         </queue>
-{% endfor %}         </anycast>
+{% if queue['durable'] is defined %}           <durable>{{ queue['durable'] | lower }}</durable>{% endif %}
+           </queue>
+{% endfor %}
+         </anycast>
 {% endif %}
 {% if address['multicast'] is defined and address['multicast'] %}
          <multicast>
 {% for queue in address['multicast'] %}
-         <queue name="{{ queue.name }}"
-                max-consumers="{{ queue['max_consumers'] | default('-1') }}"
-                exclusive="{{ queue['exclusive'] | default('false') | lower }}"
-                consumers-before-dispatch="{{ queue['consumers_before_dispatch'] | default('0') }}"
-                delay-before-dispatch="{{ queue['delay_before_dispatch'] | default('-1') }}">
+           <queue name="{{ queue.name }}"
+{% for param in lookup('ansible.builtin.dict', address.parameters, wantlist=true) %}
+{% if param.key not in ['durable','filter'] }%
+            {{ param.key | replace('_','-') }}="{% if param.value is number %}{{ param.value | string | lower }}{% else %}{{ param.value }}{% endif %} }}"
+{% endif %}
+{% endfor %}
 {% if queue['filter'] is defined %}           <filter string="{{ queue['filter'] }}"/>{% endif %}
-           <durable>{{ queue['durable'] | default('true') | lower }}</durable>
-         </queue>
-{% endfor %}         </multicast>
+{% if queue['durable'] is defined %}           <durable>{{ queue['durable'] | lower }}</durable>{% endif %}
+           </queue>
+{% endfor %}
+         </multicast>
 {% elif address['multicast'] is defined %}
          <multicast />
 {% endif %}

--- a/roles/activemq/templates/addresses.broker.xml.j2
+++ b/roles/activemq/templates/addresses.broker.xml.j2
@@ -4,7 +4,7 @@
 {% for queue in address['anycast'] %}
            <queue name="{{ queue.name }}"
 {% for param in lookup('ansible.builtin.dict', address.parameters, wantlist=true) %}
-{% if param.key not in ['durable','filter'] }%
+{% if param.key not in ['durable','filter'] %}
             {{ param.key | replace('_','-') }}="{% if param.value is number %}{{ param.value | string | lower }}{% else %}{{ param.value }}{% endif %} }}"
 {% endif %}
 {% endfor %}
@@ -19,7 +19,7 @@
 {% for queue in address['multicast'] %}
            <queue name="{{ queue.name }}"
 {% for param in lookup('ansible.builtin.dict', address.parameters, wantlist=true) %}
-{% if param.key not in ['durable','filter'] }%
+{% if param.key not in ['durable','filter'] %}
             {{ param.key | replace('_','-') }}="{% if param.value is number %}{{ param.value | string | lower }}{% else %}{{ param.value }}{% endif %} }}"
 {% endif %}
 {% endfor %}

--- a/roles/activemq/templates/addresses.broker.xml.j2
+++ b/roles/activemq/templates/addresses.broker.xml.j2
@@ -3,11 +3,12 @@
          <anycast>
 {% for queue in address['anycast'] %}
            <queue name="{{ queue.name }}"
-{% for param in lookup('ansible.builtin.dict', queue.parameters, wantlist=true) %}
+{% for param in lookup('ansible.builtin.dict', queue.parameters | d({}), wantlist=true) %}
 {% if param.key not in ['durable','filter'] %}
-            {{ param.key | replace('_','-') }}="{% if param.value is number %}{{ param.value | string | lower }}{% else %}{{ param.value }}{% endif %} }}"
+            {{ param.key | replace('_','-') }}="{% if param.value is number %}{{ param.value | string | lower }}{% else %}{{ param.value }}{% endif %}"
 {% endif %}
 {% endfor %}
+           >
 {% if queue['filter'] is defined %}           <filter string="{{ queue['filter'] }}"/>{% endif %}
 {% if queue['durable'] is defined %}           <durable>{{ queue['durable'] | lower }}</durable>{% endif %}
            </queue>
@@ -18,11 +19,12 @@
          <multicast>
 {% for queue in address['multicast'] %}
            <queue name="{{ queue.name }}"
-{% for param in lookup('ansible.builtin.dict', queue.parameters, wantlist=true) %}
+{% for param in lookup('ansible.builtin.dict', queue.parameters | d({}), wantlist=true) %}
 {% if param.key not in ['durable','filter'] %}
-            {{ param.key | replace('_','-') }}="{% if param.value is number %}{{ param.value | string | lower }}{% else %}{{ param.value }}{% endif %} }}"
+            {{ param.key | replace('_','-') }}="{% if param.value is number %}{{ param.value | string | lower }}{% else %}{{ param.value }}{% endif %}"
 {% endif %}
 {% endfor %}
+           >
 {% if queue['filter'] is defined %}           <filter string="{{ queue['filter'] }}"/>{% endif %}
 {% if queue['durable'] is defined %}           <durable>{{ queue['durable'] | lower }}</durable>{% endif %}
            </queue>

--- a/roles/activemq/templates/modular/addresses.xml.j2
+++ b/roles/activemq/templates/modular/addresses.xml.j2
@@ -6,11 +6,12 @@
         <anycast>
 {% for queue in address['anycast'] %}
           <queue name="{{ queue.name }}"
-{% for param in lookup('ansible.builtin.dict', queue.parameters, wantlist=true) %}
+{% for param in lookup('ansible.builtin.dict', queue.parameters | d({}), wantlist=true) %}
 {% if param.key not in ['durable','filter'] %}
-            {{ param.key | replace('_','-') }}="{% if param.value is number %}{{ param.value | string | lower }}{% else %}{{ param.value }}{% endif %} }}"
+            {{ param.key | replace('_','-') }}="{% if param.value is number %}{{ param.value | string | lower }}{% else %}{{ param.value }}{% endif %}"
 {% endif %}
 {% endfor %}
+           >
 {% if queue['filter'] is defined %}           <filter string="{{ queue['filter'] }}"/>{% endif %}
 {% if queue['durable'] is defined %}           <durable>{{ queue['durable'] | lower }}</durable>{% endif %}
           </queue>
@@ -21,11 +22,12 @@
         <multicast>
 {% for queue in address['multicast'] %}
           <queue name="{{ queue.name }}"
-{% for param in lookup('ansible.builtin.dict', address.parameters, wantlist=true) %}
+{% for param in lookup('ansible.builtin.dict', address.parameters | d({}), wantlist=true) %}
 {% if param.key not in ['durable','filter'] %}
-            {{ param.key | replace('_','-') }}="{% if param.value is number %}{{ param.value | string | lower }}{% else %}{{ param.value }}{% endif %} }}"
+            {{ param.key | replace('_','-') }}="{% if param.value is number %}{{ param.value | string | lower }}{% else %}{{ param.value }}{% endif %}"
 {% endif %}
 {% endfor %}
+           >
 {% if queue['filter'] is defined %}           <filter string="{{ queue['filter'] }}"/>{% endif %}
 {% if queue['durable'] is defined %}           <durable>{{ queue['durable'] | lower }}</durable>{% endif %}
           </queue>

--- a/roles/activemq/templates/modular/addresses.xml.j2
+++ b/roles/activemq/templates/modular/addresses.xml.j2
@@ -5,25 +5,25 @@
 {% if address['anycast'] is defined %}         <anycast>
 {% for queue in address['anycast'] %}
         <queue name="{{ queue.name }}"
-            max-consumers="{{ queue['max_consumers'] | default('-1') }}"
-            exclusive="{{ queue['exclusive'] | default('false') | lower }}"
-            consumers-before-dispatch="{{ queue['consumers_before_dispatch'] | default('0') }}"
-            delay-before-dispatch="{{ queue['delay_before_dispatch'] | default('-1') }}">
+{% for param in lookup('ansible.builtin.dict', address.parameters, wantlist=true) %}
+{% if param.key not in ['durable','filter'] %}
+            {{ param.key | replace('_','-') }}="{% if param.value is number %}{{ param.value | string | lower }}{% else %}{{ param.value }}{% endif %} }}"
+{% endif %}
+{% endfor %}
 {% if queue['filter'] is defined %}           <filter string="{{ queue['filter'] }}"/>{% endif %}
-        <durable>{{ queue['durable'] | default('true') | lower }}</durable>
+{% if queue['durable'] is defined %}           <durable>{{ queue['durable'] | lower }}</durable>{% endif %}
         </queue>
 {% endfor %}         </anycast>
 {% endif %}
 {% if address['multicast'] is defined and address['multicast'] %}
         <multicast>
-{% for queue in address['multicast'] %}
-        <queue name="{{ queue.name }}"
-            max-consumers="{{ queue['max_consumers'] | default('-1') }}"
-            exclusive="{{ queue['exclusive'] | default('false') | lower }}"
-            consumers-before-dispatch="{{ queue['consumers_before_dispatch'] | default('0') }}"
-            delay-before-dispatch="{{ queue['delay_before_dispatch'] | default('-1') }}">
+{% for param in lookup('ansible.builtin.dict', address.parameters, wantlist=true) %}
+{% if param.key not in ['durable','filter'] %}
+            {{ param.key | replace('_','-') }}="{% if param.value is number %}{{ param.value | string | lower }}{% else %}{{ param.value }}{% endif %} }}"
+{% endif %}
+{% endfor %}
 {% if queue['filter'] is defined %}           <filter string="{{ queue['filter'] }}"/>{% endif %}
-        <durable>{{ queue['durable'] | default('true') | lower }}</durable>
+{% if queue['durable'] is defined %}           <durable>{{ queue['durable'] | lower }}</durable>{% endif %}
         </queue>
 {% endfor %}         </multicast>
 {% elif address['multicast'] is defined %}

--- a/roles/activemq/templates/modular/addresses.xml.j2
+++ b/roles/activemq/templates/modular/addresses.xml.j2
@@ -2,21 +2,25 @@
 <addresses xmlns="urn:activemq:core">
 {% for address in activemq_addresses %}
     <address name="{{ address.name }}">
-{% if address['anycast'] is defined %}         <anycast>
+{% if address['anycast'] is defined %}
+        <anycast>
 {% for queue in address['anycast'] %}
-        <queue name="{{ queue.name }}"
-{% for param in lookup('ansible.builtin.dict', address.parameters, wantlist=true) %}
+          <queue name="{{ queue.name }}"
+{% for param in lookup('ansible.builtin.dict', queue.parameters, wantlist=true) %}
 {% if param.key not in ['durable','filter'] %}
             {{ param.key | replace('_','-') }}="{% if param.value is number %}{{ param.value | string | lower }}{% else %}{{ param.value }}{% endif %} }}"
 {% endif %}
 {% endfor %}
 {% if queue['filter'] is defined %}           <filter string="{{ queue['filter'] }}"/>{% endif %}
 {% if queue['durable'] is defined %}           <durable>{{ queue['durable'] | lower }}</durable>{% endif %}
-        </queue>
-{% endfor %}         </anycast>
+          </queue>
+{% endfor %}
+        </anycast>
 {% endif %}
 {% if address['multicast'] is defined and address['multicast'] %}
         <multicast>
+{% for queue in address['multicast'] %}
+          <queue name="{{ queue.name }}"
 {% for param in lookup('ansible.builtin.dict', address.parameters, wantlist=true) %}
 {% if param.key not in ['durable','filter'] %}
             {{ param.key | replace('_','-') }}="{% if param.value is number %}{{ param.value | string | lower }}{% else %}{{ param.value }}{% endif %} }}"
@@ -24,8 +28,9 @@
 {% endfor %}
 {% if queue['filter'] is defined %}           <filter string="{{ queue['filter'] }}"/>{% endif %}
 {% if queue['durable'] is defined %}           <durable>{{ queue['durable'] | lower }}</durable>{% endif %}
-        </queue>
-{% endfor %}         </multicast>
+          </queue>
+{% endfor %}
+        </multicast>
 {% elif address['multicast'] is defined %}
         <multicast />
 {% endif %}


### PR DESCRIPTION
Refactor `activemq_addresses` to behave in regards to parameters as `activemq_address_settings`, ie. each address iten in the list may have a `parameters` dict containing python-cased queue paramters.

```yaml
    activemq_addresses:
      - name: DLQ
        anycast:
          - name: DLQ
            parameters:
              durable: True
      - name: client123.pubsub
        multicast:
          - name: client123.pubsub.foo
            parameters:
              max_consumers: 1
              delay_before_dispatch: 3
```

Fix #169 