### PR TITLE
Check broadcast/discovery groups absent with `provided` discovery

### DIFF
--- a/roles/activemq/tasks/configure_artemis.yml
+++ b/roles/activemq/tasks/configure_artemis.yml
@@ -24,7 +24,7 @@
       - "--staticCluster {{ activemq_cluster_nodes | map(attribute='value') | join(',') }}"
   when:
     - activemq_ha_enabled
-    - activemq_cluster_discovery == "static"
+    - activemq_cluster_discovery in ["static", "provided"]
 
 - name: Enable security
   ansible.builtin.set_fact:

--- a/roles/activemq/tasks/connectors.yml
+++ b/roles/activemq/tasks/connectors.yml
@@ -33,6 +33,24 @@
     - activemq_cluster_discovery == 'static' or activemq_cluster_discovery == 'provided'
     - activemq_ha_enabled
   block:
+    - name: Remove discovery groups
+      middleware_automation.common.xml:
+        path: "{{ activemq.home }}/etc/broker.xml"
+        xpath: /conf:configuration/core:core/core:discovery-groups
+        state: absent
+        namespaces:
+          conf: urn:activemq
+          core: urn:activemq:core
+
+    - name: Remove broadcast groups
+      middleware_automation.common.xml:
+        path: "{{ activemq.home }}/etc/broker.xml"
+        xpath: /conf:configuration/core:core/core:broadcast-groups
+        state: absent
+        namespaces:
+          conf: urn:activemq
+          core: urn:activemq:core
+
     - name: Create cluster connections configuration string
       ansible.builtin.set_fact:
         cluster_connections: "{{ lookup('template', 'cluster_connections.broker.xml.j2') }}"

--- a/roles/activemq/tasks/connectors.yml
+++ b/roles/activemq/tasks/connectors.yml
@@ -35,7 +35,7 @@
   block:
     - name: Remove discovery groups
       middleware_automation.common.xml:
-        path: "{{ activemq.home }}/etc/broker.xml"
+        path: "{{ activemq.instance_home }}/etc/broker.xml"
         xpath: /conf:configuration/core:core/core:discovery-groups
         state: absent
         namespaces:
@@ -44,7 +44,7 @@
 
     - name: Remove broadcast groups
       middleware_automation.common.xml:
-        path: "{{ activemq.home }}/etc/broker.xml"
+        path: "{{ activemq.instance_home }}/etc/broker.xml"
         xpath: /conf:configuration/core:core/core:broadcast-groups
         state: absent
         namespaces:

--- a/roles/activemq/tasks/connectors.yml
+++ b/roles/activemq/tasks/connectors.yml
@@ -29,6 +29,7 @@
     - restart amq_broker
 
 - name: Configure cluster connections
+  become: true
   when:
     - activemq_cluster_discovery == 'static' or activemq_cluster_discovery == 'provided'
     - activemq_ha_enabled

--- a/roles/activemq/tasks/jgroups.yml
+++ b/roles/activemq/tasks/jgroups.yml
@@ -1,8 +1,17 @@
 ---
 - name: Remove discovery groups
   middleware_automation.common.xml:
-    path: "{{ activemq.home }}/etc/broker.xml"
+    path: "{{ activemq.instance_home }}/etc/broker.xml"
     xpath: /conf:configuration/core:core/core:discovery-groups
+    state: absent
+    namespaces:
+      conf: urn:activemq
+      core: urn:activemq:core
+
+- name: Remove broadcast groups
+  middleware_automation.common.xml:
+    path: "{{ activemq.instance_home }}/etc/broker.xml"
+    xpath: /conf:configuration/core:core/core:broadcast-groups
     state: absent
     namespaces:
       conf: urn:activemq

--- a/roles/activemq/tasks/jgroups.yml
+++ b/roles/activemq/tasks/jgroups.yml
@@ -7,6 +7,7 @@
     namespaces:
       conf: urn:activemq
       core: urn:activemq:core
+  become: true
 
 - name: Remove broadcast groups
   middleware_automation.common.xml:
@@ -16,3 +17,4 @@
     namespaces:
       conf: urn:activemq
       core: urn:activemq:core
+  become: true


### PR DESCRIPTION
A regression was introduced by #168 when `activemq_cluster_discovery: provided`, which causes failure to start services because broadcast groups refers a non-existing connector.