### PR TITLE
Update default for `activemq_systemd_wait_for_log_ha_string`

### DIFF
--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -296,7 +296,7 @@ Sample divert:
 |`activemq_systemd_wait_for_log` | Whether systemd unit should wait for service to be up in logs | `True` when `activemq_ha_enabled` and `activemq_shared_storage` are both `True` |
 |`activemq_systemd_wait_for_timeout`| How long to wait for service to be alive (seconds) | `60` |
 |`activemq_systemd_wait_for_delay`| Activation delay for service systemd unit | `10` |
-|`activemq_systemd_wait_for_log_ha_string` | The string to match in the logs when `activemq_systemd_wait_for_log` is true and HA is enabled | `AMQ221109\|AMQ221001` |
+|`activemq_systemd_wait_for_log_ha_string` | The string to match in the logs when `activemq_systemd_wait_for_log` is true and HA is enabled | `AMQ221109\|AMQ221001\|AMQ221034` |
 |`activemq_systemd_wait_for_log_string` | The string to match in the logs when `activemq_systemd_wait_for_log` is true and HA is not enabled | `AMQ221034` |
 |`activemq_systemd_wait_for_port_number`| The port number to wait for when `activemq_systemd_wait_for_port` is true | `{{ activemq_port }}` |
 |`activemq_systemd_expand_environment` | Whether or not to expand the environment in the sysconfig file. If true, environment file is sourced and the activemq process is started in a shell | `false` |

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -74,7 +74,7 @@ activemq_systemd_wait_for_port: "{{ activemq_ha_enabled and not activemq_shared_
 activemq_systemd_wait_for_log: "{{ activemq_ha_enabled and activemq_shared_storage }}"
 activemq_systemd_wait_for_timeout: 60
 activemq_systemd_wait_for_delay: 10
-activemq_systemd_wait_for_log_ha_string: 'AMQ221109\\\\|AMQ221001'
+activemq_systemd_wait_for_log_ha_string: 'AMQ221109\\\\|AMQ221001\\\\|AMQ221034'
 activemq_systemd_wait_for_log_string: 'AMQ221034'
 activemq_systemd_wait_for_port_number: "{{ activemq_port }}"
 activemq_systemd_expand_environment: false

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -748,7 +748,7 @@ argument_specs:
                 default: -1
                 type: 'int'
             activemq_systemd_wait_for_log_ha_string:
-                default: 'AMQ221109\\\\|AMQ221001'
+                default: 'AMQ221109\\\\|AMQ221001\\\\|AMQ221034'
                 type: "str"
                 description: "The string to match in the logs when activemq_systemd_wait_for_log is true and HA is enabled"
             activemq_systemd_wait_for_log_string:


### PR DESCRIPTION
The default for the parameter is updated to `AMQ221109\\\\|AMQ221001\\\\|AMQ221034`, in order to accomodate the scenario described in the linked issue.

Fix #185 