### PR TITLE
Add parameter `activemq_logger_filepath` to configure logfile path

### DIFF
--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -395,6 +395,7 @@ See _Role Variables_ below for additional TLS/SSL settings.
 |`activemq_logger_audit_rollover_files`| Number of rollover audit log files | `5` | `'log4j2.properties' if activemq_version is version_compare('2.27.0', '>=') else 'logging.properties'` |
 |`activemq_logger_config_template_path` | Optional subdirectory of any playbook template lookup directories for the logging facility configuration | `''` |
 |`activemq_logger_config_keep_name` | Whether to keep the custom template filename or use the default | `False` |
+|`activemq_logger_filepath` | Path for main logfile relative to instance directory | `/log/artemis.log` |
 
 
 #### Broker plugins

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -238,6 +238,7 @@ activemq_logger_config_template_path: ''
 activemq_logger_config_keep_name: false
 activemq_logger_rollover_files: 5
 activemq_logger_audit_rollover_files: 5
+activemq_logger_filepath: /log/artemis.log
 
 # Metrics
 activemq_jmx_exporter_port: 18080

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -813,6 +813,10 @@ argument_specs:
                 description: "Whether or not to enable clustering (cluster-connections)"
                 default: "{{ activemq_ha_enabled }}"
                 type: 'bool'
+            activemq_logger_filepath:
+                description: "Path for main logfile relative to instance directory."
+                default: "/log/artemis.log"
+                type: 'str'
     systemd:
         options:
             activemq_version:

--- a/roles/activemq/templates/log4j2.properties.j2
+++ b/roles/activemq/templates/log4j2.properties.j2
@@ -77,8 +77,8 @@ appender.console.layout.pattern=%d %-5level [%logger] %msg%n
 # Log file appender
 appender.log_file.type = RollingFile
 appender.log_file.name = log_file
-appender.log_file.fileName = ${sys:artemis.instance}/log/artemis.log
-appender.log_file.filePattern = ${sys:artemis.instance}/log/artemis.log.%d{yyyy-MM-dd}
+appender.log_file.fileName = ${sys:artemis.instance}{{ activemq_logger_filepath }}
+appender.log_file.filePattern = ${sys:artemis.instance}{{ activemq_logger_filepath }}.%d{yyyy-MM-dd}
 appender.log_file.layout.type = PatternLayout
 appender.log_file.layout.pattern = %d %-5level [%logger] %msg%n
 appender.log_file.policies.type = Policies

--- a/roles/activemq/templates/logging.properties.j2
+++ b/roles/activemq/templates/logging.properties.j2
@@ -52,7 +52,7 @@ handler.FILE.properties=suffix,append,autoFlush,fileName
 handler.FILE.suffix=.yyyy-MM-dd
 handler.FILE.append=true
 handler.FILE.autoFlush=true
-handler.FILE.fileName=${artemis.instance}/log/artemis.log
+handler.FILE.fileName=${artemis.instance}{{ activemq_logger_filepath }}
 handler.FILE.formatter=PATTERN
 
 # Formatter pattern configuration


### PR DESCRIPTION
| Variable | Description | Default |
|:---------|:------------|:--------|
|`activemq_logger_filepath` | Path for main logfile relative to instance directory | `/log/artemis.log` |