### PR TITLE
Add role expansion parameters for ldap/AD configuration

### DIFF
--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -111,6 +111,8 @@ Role Defaults
 |`activemq_auth_ldap_role_search` | Role search attribute | `(member={0})` |
 |`activemq_auth_ldap_role_search_subtree` | Whether to enable subtree role search | `False` |
 |`activemq_auth_ldap_referral` | Specify how to handle referrals; valid values: ignore, follow, throw | `ignore` |
+|`activemq_auth_ldap_expand_roles` | Whether to enable role expansion functionality; if enabled, then roles within roles will be found | `false` |
+|`activemq_auth_ldap_expand_roles_matching` | An LDAP search filter which is applied to the subtree selected by roleBase | `(member={0})` |
 
 
 #### Journal configuration

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -113,6 +113,8 @@ activemq_auth_ldap_role_name: cn
 activemq_auth_ldap_role_search: '(member={0})'
 activemq_auth_ldap_role_search_subtree: false
 activemq_auth_ldap_referral: ignore
+activemq_auth_ldap_expand_roles: false
+activemq_auth_ldap_expand_roles_matching: '(member={0})'
 
 ## Additional classpath
 activemq_additional_libs: []

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -637,6 +637,14 @@ argument_specs:
                 description: "Specify how to handle referrals; valid values: ignore, follow, throw"
                 default: "ignore"
                 type: "str"
+            activemq_auth_ldap_expand_roles:
+                description: "Whether to enable role expansion functionality or not. If enabled, then roles within roles will be found."
+                default: false
+                type: 'bool'
+            activemq_auth_ldap_expand_roles_matching:
+                description: "An LDAP search filter which is applied to the subtree selected by roleBase"
+                default: '(member={0})'
+                type: "str"
             activemq_auth_template:
                 description: "Location of JAAS login.config template; by default use template provided with activemq_hawtio_role"
                 default: "login.config.j2"

--- a/roles/activemq/templates/login.config.j2
+++ b/roles/activemq/templates/login.config.j2
@@ -49,6 +49,8 @@ activemq {
         roleSearchMatching="{{ activemq_auth_ldap_role_search }}"
         roleSearchSubtree={{ activemq_auth_ldap_role_search_subtree }}
         referral="{{ activemq_auth_ldap_referral }}"
+        expandRoles="{{ activemq_auth_ldap_expand_roles }}"
+        expandRolesMatching="{{ activemq_auth_ldap_expand_roles_matching }}"
         reload=true
     ;
 {% endif %}


### PR DESCRIPTION
New parameters to set roles in role expansion functionality allow to configure active directory as an ldap identity provider:

| Variable | Description | Default |
|:---------|:------------|:--------|
|`activemq_auth_ldap_expand_roles` | Whether to enable role expansion functionality; if enabled, then roles within roles will be found | `false` |
|`activemq_auth_ldap_expand_roles_matching` | An LDAP search filter which is applied to the subtree selected by roleBase | `(member={0})` |

Fix #188 