### PR TITLE
Fix password masking command JDK

### DIFF
--- a/roles/activemq/tasks/install.yml
+++ b/roles/activemq/tasks/install.yml
@@ -81,6 +81,8 @@
     mode: '0640'
   delegate_to: localhost
   run_once: true
+  retries: 3
+  delay: 20
   when:
     - archive_path is defined
     - archive_path.stat is defined

--- a/roles/activemq/tasks/mask_password.yml
+++ b/roles/activemq/tasks/mask_password.yml
@@ -1,45 +1,66 @@
 ---
-- name: "Set masked (hashed) user password for {{ item.user }}"
+- name: "Set masked hashed user password in user list"
   block:
-    - name: Parse passwd hash for existing user
-      ansible.builtin.set_fact:
-        existing_user: "{{ existing_users.content | b64decode
-                         | regex_search('\\b' + item.user + ' ?= ?ENC\\([0-9]+:([^:]+):([^)]+)\\)', '\\1', '\\2') | default([]) }}"
-        mask_pwd: ''
+    - name: "Set when requires to parse masked password salt"
       when:
         - not item.password is defined or not item.password is regex('^ENC\\([0-9]{4,}:[^:]+:[^:]+\\)')
+      block:
+        - name: "Parse passwd hash for existing user: {{ item.user }}"
+          ansible.builtin.set_fact:
+            existing_user: "{{ existing_users.content | b64decode
+                            | regex_search('\\b' + item.user + ' ?= ?ENC\\([0-9]+:([^:]+):([^)]+)\\)', '\\1', '\\2') | default([]) }}"
+            mask_pwd: ''
+          no_log: true
 
-    - name: Parse passwd for existing user salt
-      ansible.builtin.set_fact:
-        hash_password: "{{ item.password | middleware_automation.amq.pbkdf2_hmac(
-                           hashname=activemq_mask_password_hashname, iterations=activemq_mask_password_iterations, hexsalt=existing_user[0]) }}"
-      when: existing_user | length > 0
-      no_log: true
+        - name: "Parse passwd for existing user salt: {{ item.user }}"
+          ansible.builtin.set_fact:
+            hash_password: "{{ item.password | middleware_automation.amq.pbkdf2_hmac(
+                              hashname=activemq_mask_password_hashname,
+                              iterations=activemq_mask_password_iterations, hexsalt=existing_user[0]) }}"
+          when:
+            - existing_user is defined and existing_user | length > 0
+          no_log: true
 
-    - name: Get masked password for user
-      ansible.builtin.command: "{{ activemq.instance_home }}/bin/artemis mask --hash {{ '--password-codec' if activemq_password_codec != 'org.apache.activemq.artemis.utils.DefaultSensitiveStringCodec' else '' }} -- '{{ item.password }}'"
-      become: true
-      become_user: "{{ activemq_service_user }}"
-      register: mask_pwd
-      changed_when: false
-      no_log: true
-      when:
-        - not item.password is defined or not item.password is regex('^ENC\\([0-9]{4,}:[^:]+:[^:]+\\)')
-        - existing_user | length == 0 or hash_password != existing_user[1]
+        - name: Get masked password for user
+          ansible.builtin.command:
+            cmd: "{{ activemq.instance_home }}/bin/artemis mask --hash {{ '--password-codec' if activemq_password_codec != 'org.apache.activemq.artemis.utils.DefaultSensitiveStringCodec' else '' }} -- '{{ item.password }}'"
+          environment:
+            PATH: "{{ rpm_java_home | default(activemq_rpm_java_home, true) }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+            JAVA_HOME: "{{ rpm_java_home }}"
+          become: true
+          become_user: "{{ activemq_service_user }}"
+          no_log: true
+          register: mask_pwd
+          changed_when: false
+          when:
+            - existing_user is not defined or existing_user | length == 0 or hash_password != existing_user[1]
 
-    - name: Add new masked password to users list
-      ansible.builtin.set_fact:
-        masked_users: "{{ masked_users | default([]) +
-                          [{ 'user': item.user,
-                             'password': mask_pwd.stdout | regex_search('result: (.+)', '\\1', multiline=true) | first,
-                             'roles': item.roles }] }}"
-      no_log: true
-      when:
-        - existing_user | length == 0 or hash_password != existing_user[1]
-        - item.password is defined and item.password | length > 0
-        - not item.password is regex('^ENC\\([0-9]{4,}:[^:]+:[^:]+\\)')
+        - name: Add existing user with new masked password to users list
+          ansible.builtin.set_fact:
+            masked_users: "{{ masked_users | default([]) +
+                              [{ 'user': item.user,
+                                'password': mask_pwd.stdout | regex_search('result: (.+)', '\\1', multiline=true) | first,
+                                'roles': item.roles }] }}"
+          no_log: true
+          when:
+            - existing_user is not defined or existing_user | length == 0 or hash_password != existing_user[1]
+            - item.password is defined and item.password | length > 0
+            - not item.password is regex('^ENC\\([0-9]{4,}:[^:]+:[^:]+\\)')
 
-    - name: Add already masked password to users list
+        - name: Add existing user with current masked password to users list
+          ansible.builtin.set_fact:
+            masked_users: "{{ masked_users | default([]) +
+                              [{ 'user': item.user,
+                                'password': activemq_mask_password_iterations | string + ':' + existing_user[0] + ':' + existing_user[1],
+                                'roles': item.roles }] }}"
+          no_log: true
+          when:
+            - existing_user is defined and existing_user | length > 0
+            - hash_password == existing_user[1]
+            - item.password is defined and item.password | length > 0
+            - not item.password is regex('^ENC\\([0-9]{4,}:[^:]+:[^:]+\\)')
+
+    - name: Add user with pre-masked password to users list
       ansible.builtin.set_fact:
         masked_users: "{{ masked_users | default([]) +
                           [{ 'user': item.user,
@@ -49,16 +70,3 @@
       when:
         - item.password is defined and item.password | length > 0
         - item.password is regex('^ENC\\([0-9]{4,}:[^:]+:[^:]+\\)')
-
-    - name: Add existing user to users list
-      ansible.builtin.set_fact:
-        masked_users: "{{ masked_users | default([]) +
-                          [{ 'user': item.user,
-                             'password': activemq_mask_password_iterations | string + ':' + existing_user[0] + ':' + existing_user[1],
-                             'roles': item.roles }] }}"
-      no_log: true
-      when:
-        - existing_user | length > 0
-        - hash_password == existing_user[1]
-        - item.password is defined and item.password | length > 0
-        - not item.password is regex('^ENC\\([0-9]{4,}:[^:]+:[^:]+\\)')


### PR DESCRIPTION
When mask passwords are generated via `artemis mask` command, the configured JDK is not used.
Refactor the blocks in the mark_passwords.yml taskfile to guard against undefined vars

Fix #196 
Fix #197 