### PR TITLE
Update CI to have some podman self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,8 @@ jobs:
       fqcn: 'middleware_automation/amq'
       debug_verbosity: "${{ github.event.inputs.debug_verbosity }}"
       molecule_tests: >-
-        [ "default", "static_cluster", "replication", "live_only", "mirroring", "federation", "amq_upgrade", "mask_passwords", "custom_xml", "uninstall" ]
+        [ "static_cluster", "replication", "live_only", "mirroring", "federation", "amq_upgrade", "mask_passwords" ]
+      podman_tests_current: >-
+        [ "default", "custom_xml", "uninstall" ]
+      podman_tests_next: >-
+        [ "default", "custom_xml", "uninstall" ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
       fqcn: 'middleware_automation/amq'
       debug_verbosity: "${{ github.event.inputs.debug_verbosity }}"
       molecule_tests: >-
-        [ "static_cluster", "replication", "live_only", "mirroring", "federation", "amq_upgrade", "mask_passwords" ]
+        [ "static_cluster", "replication", "live_only", "mirroring", "federation" ]
       podman_tests_current: >-
-        [ "default", "custom_xml", "uninstall" ]
+        [ "default", "amq_upgrade", "custom_xml", "mask_passwords", "uninstall" ]
       podman_tests_next: >-
-        [ "default", "custom_xml", "uninstall" ]
+        [ "default", "amq_upgrade", "custom_xml", "mask_passwords", "uninstall" ]

--- a/molecule/amq_upgrade/molecule.yml
+++ b/molecule/amq_upgrade/molecule.yml
@@ -1,15 +1,12 @@
 ---
 driver:
-  name: docker
+  name: podman
 platforms:
-  - name: instance
+  - name: amq_upgrade
     image: registry.access.redhat.com/ubi8/ubi-init:latest
     pre_build_image: true
     privileged: true
     command: "/usr/sbin/init"
-    tmpfs:
-      - /run
-      - /tmp
 provisioner:
   name: ansible
   config_options:

--- a/molecule/custom_xml/molecule.yml
+++ b/molecule/custom_xml/molecule.yml
@@ -2,15 +2,11 @@
 driver:
   name: podman
 platforms:
-  - name: instance
+  - name: amq_custom_xml
     image: registry.access.redhat.com/ubi8/ubi-init:latest
     pre_build_image: true
     privileged: true
     command: "/usr/sbin/init"
-    port_bindings:
-      - 8161:8161
-    published_ports:
-      - 0.0.0.0:8161:8161/TCP
 provisioner:
   name: ansible
   config_options:

--- a/molecule/custom_xml/molecule.yml
+++ b/molecule/custom_xml/molecule.yml
@@ -1,15 +1,12 @@
 ---
 driver:
-  name: docker
+  name: podman
 platforms:
   - name: instance
     image: registry.access.redhat.com/ubi8/ubi-init:latest
     pre_build_image: true
     privileged: true
     command: "/usr/sbin/init"
-    tmpfs:
-      - /run
-      - /tmp
     port_bindings:
       - 8161:8161
     published_ports:

--- a/molecule/custom_xml/verify.yml
+++ b/molecule/custom_xml/verify.yml
@@ -37,7 +37,7 @@
         fail_msg: "Wrong ownership of instance directories"
 
     - name: Check all port numbers are accessible from the current host
-      wait_for:
+      ansible.builtin.wait_for:
         host: localhost
         port: "{{ item }}"
         state: started

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -2,15 +2,11 @@
 driver:
   name: podman
 platforms:
-  - name: instance
+  - name: amq_default
     image: registry.access.redhat.com/ubi9/ubi-init:latest
     pre_build_image: true
     privileged: true
     command: "/usr/sbin/init"
-    port_bindings:
-      - 8161:8161
-    published_ports:
-      - 0.0.0.0:8161:8161/TCP
 provisioner:
   name: ansible
   config_options:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,15 +1,12 @@
 ---
 driver:
-  name: docker
+  name: podman
 platforms:
   - name: instance
     image: registry.access.redhat.com/ubi9/ubi-init:latest
     pre_build_image: true
     privileged: true
     command: "/usr/sbin/init"
-    tmpfs:
-      - /run
-      - /tmp
     port_bindings:
       - 8161:8161
     published_ports:

--- a/molecule/mask_passwords/molecule.yml
+++ b/molecule/mask_passwords/molecule.yml
@@ -1,19 +1,12 @@
 ---
 driver:
-  name: docker
+  name: podman
 platforms:
-  - name: instance
+  - name: mask_passwords
     image: registry.access.redhat.com/ubi8/ubi-init:latest
     pre_build_image: true
     privileged: true
     command: "/usr/sbin/init"
-    tmpfs:
-      - /run
-      - /tmp
-    port_bindings:
-      - 8161:8161
-    published_ports:
-      - 0.0.0.0:8161:8161/TCP
 provisioner:
   name: ansible
   config_options:

--- a/molecule/requirements.yml
+++ b/molecule/requirements.yml
@@ -3,3 +3,4 @@ collections:
   - name: community.general
   - name: community.docker
     version: ">=1.9.1"
+  - name: containers.podman

--- a/molecule/uninstall/molecule.yml
+++ b/molecule/uninstall/molecule.yml
@@ -1,15 +1,12 @@
 ---
 driver:
-  name: docker
+  name: podman
 platforms:
   - name: instance
     image: registry.access.redhat.com/ubi9/ubi-init:latest
     pre_build_image: true
     privileged: true
     command: "/usr/sbin/init"
-    tmpfs:
-      - /run
-      - /tmp
     port_bindings:
       - 8161:8161
     published_ports:

--- a/molecule/uninstall/molecule.yml
+++ b/molecule/uninstall/molecule.yml
@@ -2,15 +2,11 @@
 driver:
   name: podman
 platforms:
-  - name: instance
+  - name: amq_uninstall
     image: registry.access.redhat.com/ubi9/ubi-init:latest
     pre_build_image: true
     privileged: true
     command: "/usr/sbin/init"
-    port_bindings:
-      - 8161:8161
-    published_ports:
-      - 0.0.0.0:8161:8161/TCP
 provisioner:
   name: ansible
   config_options:

--- a/roles/activemq/tasks/install.yml
+++ b/roles/activemq/tasks/install.yml
@@ -92,11 +92,12 @@
       retries: 3
       delay: 20
   rescue:
-    - name: Recover from failed download using curl
-      ansible.builtin.command: |
+    - name: Download recovery from failed get_url module
+      ansible.builtin.command: |  # noqa command-instead-of-module get_url fails sometimes with no IPv6 support
         curl '{{ activemq.download_url }}' -4 --output "{{ local_path.stat.path }}/{{ activemq.bundle }}"
       delegate_to: localhost
       run_once: true
+      changed_when: true
 
 - name: Download AMQ broker from RHN using JBoss Network API
   delegate_to: localhost

--- a/roles/activemq/tasks/install.yml
+++ b/roles/activemq/tasks/install.yml
@@ -75,20 +75,28 @@
 
 ## download to controller
 - name: Download activemq archive
-  ansible.builtin.get_url: # noqa risky-file-permissions delegated, uses controller host user
-    url: "{{ activemq.download_url }}"
-    dest: "{{ local_path.stat.path }}/{{ activemq.bundle }}"
-    mode: '0640'
-  delegate_to: localhost
-  run_once: true
-  retries: 3
-  delay: 20
   when:
     - archive_path is defined
     - archive_path.stat is defined
     - not archive_path.stat.exists
     - not amq_broker_enable is defined or not amq_broker_enable
     - not activemq_offline_install
+  block:
+    - name: Download activemq archive
+      ansible.builtin.get_url: # noqa risky-file-permissions delegated, uses controller host user
+        url: "{{ activemq.download_url }}"
+        dest: "{{ local_path.stat.path }}/{{ activemq.bundle }}"
+        mode: '0640'
+      delegate_to: localhost
+      run_once: true
+      retries: 3
+      delay: 20
+  rescue:
+    - name: Recover from failed download using curl
+      ansible.builtin.command: |
+        curl '{{ activemq.download_url }}' -4 --output "{{ local_path.stat.path }}/{{ activemq.bundle }}"
+      delegate_to: localhost
+      run_once: true
 
 - name: Download AMQ broker from RHN using JBoss Network API
   delegate_to: localhost

--- a/roles/activemq/tasks/install.yml
+++ b/roles/activemq/tasks/install.yml
@@ -94,10 +94,12 @@
   rescue:
     - name: Download recovery from failed get_url module
       ansible.builtin.command: |  # noqa command-instead-of-module get_url fails sometimes with no IPv6 support
-        curl '{{ activemq.download_url }}' -4 --output "{{ local_path.stat.path }}/{{ activemq.bundle }}"
+        curl '{{ activemq.download_url }}' -v -4 --output "{{ local_path.stat.path }}/{{ activemq.bundle }}"
       delegate_to: localhost
       run_once: true
       changed_when: true
+      retries: 3
+      delay: 20
 
 - name: Download AMQ broker from RHN using JBoss Network API
   delegate_to: localhost


### PR DESCRIPTION
Workaround failed downloads for "error 101 - network unreachable". It only happened in CI till now, in rare cases when IPv6 is not available/not supported, but it is better to make it a main feature.