### PR TITLE
user roles have to be unique

### DIFF
--- a/roles/activemq/templates/artemis-roles.properties.j2
+++ b/roles/activemq/templates/artemis-roles.properties.j2
@@ -16,6 +16,8 @@
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
 
-{% for role in activemq_roles %}
-{{ role.name }}={{ activemq_users | selectattr('roles','issuperset',[ role.name ]) | list | map(attribute='user') | list | join(',') }}
+{% set roles = activemq_roles | map(attribute='name') | unique | list %}
+
+{% for role in roles %}
+{{ role }}={{ activemq_users | selectattr('roles','issuperset',[ role ]) | list | map(attribute='user') | list | join(',') }}
 {% endfor %}


### PR DESCRIPTION
We have more than 100 roles and about 60 users.
Same roles are allowed on multiple security-setting match.
If one role is configured more than once in the activemq_roles it is duplicated each time in artemis-roles.properties.

This PR is a suggestion to remove duplicate roles.

FYI: this PR is from my private account behind AWD09. We have migrated to GH Enterprise and I am not allowed to open issues or fork repos on my pro account anymore.
We are using the amq_broker playbook.

#####  STEPS TO REPRODUCE

```yaml
---

- name: reproduce roles generation
  hosts: localhost
  vars:
    amq_broker_users:
      - user: one
        password: abc
        roles: [ role_a ]
      - user: two
        password: abc
        roles: [ role_a, role_b ]
    amq_broker_roles:
      - match: a.queue.*
        name: role_a
        permissions: [ createAddress, createDurableQueue, createNonDurableQueue, deleteAddress, deleteDurableQueue, deleteNonDurableQueue, manage, send ]
      - match: an.other.queue.*
        name: role_b
        permissions: [ createAddress, createDurableQueue, createNonDurableQueue, deleteAddress, deleteDurableQueue, deleteNonDurableQueue, manage, send ]
      - match: a.last.queue.*
        name: role_a
        permissions: [ manage, send ]
  tasks:
    - name: Configure roles
      ansible.builtin.template:
        src: artemis-roles.properties.j2
        dest: artemis-roles.properties

```
The content of artemis-roles.properties is
```
role_a=one,two
role_b=two
role_a=one,two
```
'role_a' is present 2 times