### PR TITLE
Bump down version to 2.2.8

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: middleware_automation
 name: amq
-version: "2.3.0"
+version: "2.2.8"
 readme: README.md
 authors:
   - Guido Grazioli <ggraziol@redhat.com>


### PR DESCRIPTION
There is only one functionnal change since 2.2.7 and its a minor fixes, thus making the next release a micro one.