### PR TITLE
Add parameter `activemq_ha_backup_failover_on_shutdown`

### DIFF
--- a/molecule/static_cluster/molecule.yml
+++ b/molecule/static_cluster/molecule.yml
@@ -57,6 +57,7 @@ provisioner:
                   address_match: 'a.#'
       instance2:
         activemq_ha_role: 'backup'
+        activemq_ha_backup_failover_on_shutdown: true
   env:
     ANSIBLE_FORCE_COLOR: "true"
     PROXY: "${PROXY}"

--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -303,7 +303,8 @@ Sample divert:
 |`activemq_systemd_wait_for_port_number`| The port number to wait for when `activemq_systemd_wait_for_port` is true | `{{ activemq_port }}` |
 |`activemq_systemd_expand_environment` | Whether or not to expand the environment in the sysconfig file. If true, environment file is sourced and the activemq process is started in a shell | `false` |
 |`activemq_ha_allow_failback`| Whether a server will automatically stop when another places a request to take over its place |`true` |
-|`activemq_ha_failover_on_shutdown`| Will this backup server become active on a normal server shutdown  | `true` |
+|`activemq_ha_failover_on_shutdown`| For a master broker, determines whether to fail over to a slave if it is shut down | `true` |
+|`activemq_ha_backup_failover_on_shutdown`| For a slave broker, this element determines whether it becomes the master in case the master is shut down | `false` |
 |`activemq_ha_restart_backup`| Will this server, if a backup, restart once it has been stopped because of failback or scaling down | `false` |
 |`activemq_ha_check_for_active_server`| Whether to check the cluster for a live server using our own server ID when starting up. This option is only necessary for performing 'fail-back' on replicating servers | `false` |
 |`activemq_ha_replication_cluster_name`| Name of the cluster configuration to use for replication. This setting is only necessary in case you configure multiple cluster connections | `""` |

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -81,6 +81,7 @@ activemq_systemd_expand_environment: false
 activemq_ha_role: live-only
 activemq_ha_allow_failback: true
 activemq_ha_failover_on_shutdown: true
+activemq_ha_backup_failover_on_shutdown: false
 activemq_ha_restart_backup: false
 activemq_ha_check_for_active_server: "{{ activemq_replication }}"
 activemq_ha_replication_cluster_name: ''

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -732,7 +732,13 @@ argument_specs:
             activemq_ha_failover_on_shutdown:
                 default: true
                 type: "bool"
-                description: "Will this backup server become active on a normal server shutdown"
+                description: >
+                  For a master broker, determines whether to fail over to a slave if it is shut down.
+            activemq_ha_backup_failover_on_shutdown:
+                description: >
+                  For a slave broker, this element determines whether it becomes the master in case the master is shut down.
+                default: false
+                type: 'bool'
             activemq_ha_restart_backup:
                 default: false
                 type: "bool"

--- a/roles/activemq/templates/ha_policy.xml.j2
+++ b/roles/activemq/templates/ha_policy.xml.j2
@@ -20,6 +20,7 @@
           <{{ activemq_ha_role }}>
             <allow-failback>{{ activemq_ha_allow_failback | lower }}</allow-failback>
             <restart-backup>{{ activemq_ha_restart_backup | lower }}</restart-backup>
+            <failover-on-shutdown>{{ activemq_ha_backup_failover_on_shutdown | lower }}</failover-on-shutdown>
           </{{ activemq_ha_role }}>
 {% elif activemq_ha_role == 'master' or activemq_ha_role == 'primary' %}
           <{{ activemq_ha_role }}>


### PR DESCRIPTION
The new role parameter allows to control failover-on-shutdown in backup instances, not to be confused with `activemq_ha_failover_on_shutdown`.

| Variable | Description | Default |
|:---------|:------------|:--------|
|`activemq_ha_failover_on_shutdown`| For a master broker, determines whether to fail over to a slave if it is shut down | `true` |
|`activemq_ha_backup_failover_on_shutdown`| For a slave broker, this element determines whether it becomes the master in case the master is shut down | `false` |



Fix #200 