### PR TITLE
fix amq-broker installer schema directory not writable

### DIFF
--- a/roles/activemq/tasks/user_roles.yml
+++ b/roles/activemq/tasks/user_roles.yml
@@ -133,6 +133,7 @@
     dest: "{{ activemq_installdir }}/schema/activemq_fix.xsd"
     mode: '0644'
     remote_src: true
+  become: "{{ activemq_install_requires_become | default(true) }}"
   changed_when: false  # it does not change targets, needed for validation only
 
 # the following workaround bypasses an issue in lxml finding the xsd ambiguous
@@ -141,6 +142,7 @@
     path: "{{ activemq_installdir }}/schema/activemq_fix.xsd"
     search_string: '<xs:element name="broker" type="tns:brokerDTO"/>'
     state: absent
+  become: "{{ activemq_install_requires_become | default(true) }}"
   changed_when: false  # it does not change targets, needed for validation only
 
 - name: Validate access configuration


### PR DESCRIPTION
I am facing an error with the last change: "Destination /var/opt/amq-broker/amq-broker-7.12.1/schema not writable."
This is a PR to 'become' if needed.

The full AAP error:

```
Task: Make collection other xsd available for validation
Module: ansible.builtin.copy
```
```json
{
  "msg": "Destination /var/opt/amq-broker/amq-broker-7.12.1/schema not writable",
  "invocation": {
    "module_args": {
      "src": "/var/opt/amq-broker/amq-broker-7.12.1/schema/activemq.xsd",
      "dest": "/var/opt/amq-broker/amq-broker-7.12.1/schema/amq_broker_fix.xsd",
      "mode": "0644",
      "remote_src": true,
      "backup": false,
      "force": true,
      "follow": false,
      "unsafe_writes": false,
      "_original_basename": null,
      "content": null,
      "validate": null,
      "directory_mode": null,
      "local_follow": null,
      "checksum": null,
      "owner": null,
      "group": null,
      "seuser": null,
      "serole": null,
      "selevel": null,
      "setype": null,
      "attributes": null
    }
  },
  "_ansible_no_log": false,
  "changed": false
}
```