### PR TITLE
Optimize security settings creation with custom filter

### DIFF
--- a/plugins/filter/create_security_matches.py
+++ b/plugins/filter/create_security_matches.py
@@ -1,0 +1,91 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.errors import AnsibleFilterError
+
+DOCUMENTATION = '''
+  name: create_security_matches
+  short_description: Create security settings matches from AMQ broker roles
+  version_added: 2.3.6
+  description:
+    - Processes AMQ broker roles and permissions to create security settings matches.
+  positional: _input
+  options:
+    _input:
+      description: List of AMQ broker role dictionaries.
+      type: list
+      elements: dictionary
+      required: true
+  notes:
+    - Each role dict must have 'name' field.
+    - The 'match' field is optional and defaults to '#'.
+    - The 'permissions' field should be a list.
+  author:
+    - Martin Cihlar (mcihlar@redhat.com)
+'''
+
+EXAMPLES = '''
+# Create security settings matches from roles
+- name: Create security settings
+  ansible.builtin.set_fact:
+    security_settings_matches: "{{ activemq_roles | middleware_automation.amq.create_security_matches }}"
+'''
+
+RETURN = '''
+  _value:
+    description: Dictionary mapping match patterns to permissions and roles.
+    type: dict
+    returned: always
+'''
+
+
+def create_security_matches(amq_broker_roles):
+    """
+    Build security settings matches from AMQ broker roles.
+
+    Efficiently processes roles and permissions without expensive
+    subelements/combine operations.
+
+    Args:
+        amq_broker_roles: List of role dicts with 'name', 'match', 'permissions'
+
+    Returns:
+        Dict of {match_pattern: {permission: [role_names]}}
+    """
+    if not isinstance(amq_broker_roles, list):
+        raise AnsibleFilterError(
+            'create_security_matches requires a list of roles'
+        )
+
+    result = {}
+
+    for role in amq_broker_roles:
+        role_name = role.get('name')
+
+        if not role_name:
+            raise AnsibleFilterError(
+                f"Role missing required 'name' field: {role}"
+            )
+
+        match_pattern = role.get('match') or '#'
+        permissions = role.get('permissions', [])
+
+        if match_pattern not in result:
+            result[match_pattern] = {}
+
+        for permission in permissions:
+            if permission not in result[match_pattern]:
+                result[match_pattern][permission] = []
+
+            result[match_pattern][permission].append(role_name)
+
+    return result
+
+
+class FilterModule(object):
+    """AMQ security settings filter plugin"""
+
+    def filters(self):
+        return {
+            'create_security_matches': create_security_matches,
+        }

--- a/roles/activemq/tasks/user_roles.yml
+++ b/roles/activemq/tasks/user_roles.yml
@@ -43,13 +43,7 @@
 
 - name: Create security settings matches
   ansible.builtin.set_fact:
-    security_settings_matches: "{{ security_settings_matches | default({}) | \
-                                   combine( { match: { item.1: [ item.0.name ] }  }, recursive=true, list_merge='append' ) }}"
-  vars:
-    match: "{{ item.0.match | default('#') }}"
-  loop: "{{ activemq_roles | subelements('permissions') }}"
-  loop_control:
-    label: "{{ item.0.match | default('#') }}"
+    security_settings_matches: "{{ activemq_roles | middleware_automation.amq.create_security_matches }}"
 
 - name: Create security settings
   ansible.builtin.set_fact:

--- a/roles/activemq/tasks/validate_config.yml
+++ b/roles/activemq/tasks/validate_config.yml
@@ -171,12 +171,7 @@
 
 - name: Create security settings matches
   ansible.builtin.set_fact:
-    validate_security_settings_matches: "{{ validate_security_settings_matches | default({}) | combine( { match: { item.1: [ item.0.name ] }  }, recursive=true, list_merge='append' ) }}"
-  vars:
-    match: "{{ item.0.match | default('#') }}"
-  loop: "{{ activemq_roles | subelements('permissions') }}"
-  loop_control:
-    label: "{{ item.0.match | default('#') }}"
+    validate_security_settings_matches: "{{ activemq_roles | middleware_automation.amq.create_security_matches }}"
 
 - name: Create security settings
   ansible.builtin.set_fact:


### PR DESCRIPTION
AMW issue: https://redhat.atlassian.net/browse/AMW-506
GitHub issue: https://github.com/ansible-middleware/amq/issues/248

Replace expensive loop pattern using subelements() and combine() with efficient filter plugin. 
Provides significant performance improvement for deployments with large numbers of roles and permissions.

- Add create_security_matches filter plugin
- Update user_roles.yml to use new filter
- Update validate_config.yml to use new filter