### PR TITLE
Add comprehensive tests for create_security_matches filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,4 @@ jobs:
       fqcn: 'middleware_automation/amq'
       root_permission_varname: 'activemq_install_requires_become'
       molecule_tests: >-
-        [ "default", "amq_upgrade", "static_cluster", "replication", "schema_validation", "live_only", "mirroring", "custom_xml", "federation", "mask_passwords", "uninstall", "console_access" ]
+        [ "default", "amq_upgrade", "static_cluster", "replication", "schema_validation", "security_matches", "live_only", "mirroring", "custom_xml", "federation", "mask_passwords", "uninstall", "console_access" ]

--- a/molecule/security_matches/converge.yml
+++ b/molecule/security_matches/converge.yml
@@ -1,0 +1,154 @@
+---
+- name: Execute create_security_matches filter tests
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: "Test 1: Normal role with all fields"
+      ansible.builtin.set_fact:
+        test1_result: "{{ test_roles | middleware_automation.amq.create_security_matches }}"
+        cacheable: yes
+      vars:
+        test_roles:
+          - name: admin
+            match: '#'
+            permissions: [send, consume, manage]
+
+    - name: "Test 2: Role without 'match' field"
+      ansible.builtin.set_fact:
+        test2_result: "{{ test_roles | middleware_automation.amq.create_security_matches }}"
+        cacheable: yes
+      vars:
+        test_roles:
+          - name: manager
+            permissions: [browse, manage]
+
+    - name: "Test 3: Role with match: None"
+      ansible.builtin.set_fact:
+        test3_result: "{{ test_roles | middleware_automation.amq.create_security_matches }}"
+        cacheable: yes
+      vars:
+        test_roles:
+          - name: consumer
+            match: null
+            permissions: [consume]
+
+    - name: "Test 4: Role with match: ''"
+      ansible.builtin.set_fact:
+        test4_result: "{{ test_roles | middleware_automation.amq.create_security_matches }}"
+        cacheable: yes
+      vars:
+        test_roles:
+          - name: producer
+            match: ''
+            permissions: [send]
+
+    - name: "Test 5: Role with empty permissions"
+      ansible.builtin.set_fact:
+        test5_result: "{{ test_roles | middleware_automation.amq.create_security_matches }}"
+        cacheable: yes
+      vars:
+        test_roles:
+          - name: noperm
+            match: 'test.#'
+            permissions: []
+
+    - name: "Test 6: Multiple roles same match pattern"
+      ansible.builtin.set_fact:
+        test6_result: "{{ test_roles | middleware_automation.amq.create_security_matches }}"
+        cacheable: yes
+      vars:
+        test_roles:
+          - name: admin
+            match: 'topics.#'
+            permissions: [send, consume]
+          - name: user
+            match: 'topics.#'
+            permissions: [send]
+
+    - name: "Test 7: Empty roles list"
+      ansible.builtin.set_fact:
+        test7_result: "{{ test_roles | middleware_automation.amq.create_security_matches }}"
+        cacheable: yes
+      vars:
+        test_roles: []
+
+    - name: "Test 8: Role missing 'name' field (expect error)"
+      ansible.builtin.set_fact:
+        test8_result: "{{ test_roles | middleware_automation.amq.create_security_matches }}"
+      vars:
+        test_roles:
+          - match: '#'
+            permissions: [send]
+      register: test8_error
+      ignore_errors: yes
+
+    - name: "Cache test 8 error status"
+      ansible.builtin.set_fact:
+        test8_failed: "{{ test8_error is failed }}"
+        test8_msg: "{{ test8_error.msg | default('') }}"
+        cacheable: yes
+
+    - name: "Test 9: Role with name: None (expect error)"
+      ansible.builtin.set_fact:
+        test9_result: "{{ test_roles | middleware_automation.amq.create_security_matches }}"
+      vars:
+        test_roles:
+          - name: null
+            permissions: [send]
+      register: test9_error
+      ignore_errors: yes
+
+    - name: "Cache test 9 error status"
+      ansible.builtin.set_fact:
+        test9_failed: "{{ test9_error is failed }}"
+        test9_msg: "{{ test9_error.msg | default('') }}"
+        cacheable: yes
+
+    - name: "Test 10: Role with name: '' (expect error)"
+      ansible.builtin.set_fact:
+        test10_result: "{{ test_roles | middleware_automation.amq.create_security_matches }}"
+      vars:
+        test_roles:
+          - name: ''
+            permissions: [send]
+      register: test10_error
+      ignore_errors: yes
+
+    - name: "Cache test 10 error status"
+      ansible.builtin.set_fact:
+        test10_failed: "{{ test10_error is failed }}"
+        test10_msg: "{{ test10_error.msg | default('') }}"
+        cacheable: yes
+
+    - name: "Test 11: Input is not a list (expect error)"
+      ansible.builtin.set_fact:
+        test11_result: "{{ test_roles | middleware_automation.amq.create_security_matches }}"
+      vars:
+        test_roles:
+          name: admin
+          permissions: [send]
+      register: test11_error
+      ignore_errors: yes
+
+    - name: "Cache test 11 error status"
+      ansible.builtin.set_fact:
+        test11_failed: "{{ test11_error is failed }}"
+        test11_msg: "{{ test11_error.msg | default('') }}"
+        cacheable: yes
+
+    - name: "Test 12: Multiple roles same match, first with empty permissions"
+      ansible.builtin.set_fact:
+        test12_result: "{{ test_roles | middleware_automation.amq.create_security_matches }}"
+        cacheable: yes
+      vars:
+        test_roles:
+          - name: noperm
+            match: 'orders.#'
+            permissions: []
+          - name: reader
+            match: 'orders.#'
+            permissions: [consume, browse]
+
+    - name: "Converge phase complete"
+      ansible.builtin.debug:
+        msg: "All filter executions complete. Results cached for verification."

--- a/molecule/security_matches/molecule.yml
+++ b/molecule/security_matches/molecule.yml
@@ -1,0 +1,46 @@
+---
+driver:
+  name: podman
+platforms:
+  - name: security_matches
+    image: registry.access.redhat.com/ubi9/ubi-init:latest
+    pre_build_image: true
+    privileged: true
+    command: "/usr/sbin/init"
+    systemd: always
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+      fact_caching: jsonfile
+      fact_caching_connection: /tmp/ansible_facts_cache
+      fact_caching_timeout: 3600
+      deprecation_warnings: false
+    ssh_connection:
+      pipelining: false
+  playbooks:
+    prepare: prepare.yml
+    converge: converge.yml
+    verify: verify.yml
+  inventory:
+    host_vars:
+      localhost:
+        ansible_python_interpreter: "{{ ansible_playbook_python }}"
+  env:
+    ANSIBLE_FORCE_COLOR: "true"
+    PROXY: "${PROXY}"
+    NO_PROXY: "${NO_PROXY}"
+verifier:
+  name: ansible
+scenario:
+  test_sequence:
+    - cleanup
+    - destroy
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - cleanup
+    - destroy

--- a/molecule/security_matches/prepare.yml
+++ b/molecule/security_matches/prepare.yml
@@ -1,0 +1,2 @@
+---
+- import_playbook: ../prepare.yml

--- a/molecule/security_matches/verify.yml
+++ b/molecule/security_matches/verify.yml
@@ -1,0 +1,114 @@
+---
+- name: Verify create_security_matches filter results
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: "Test 1: Normal role with all fields"
+      ansible.builtin.assert:
+        that:
+          - test1_result is mapping
+          - "'#' in test1_result"
+          - test1_result['#']['send'] == ['admin']
+          - test1_result['#']['consume'] == ['admin']
+          - test1_result['#']['manage'] == ['admin']
+        success_msg: "Test 1 passed: Normal role processed correctly"
+        fail_msg: "Test 1 failed: Normal role output incorrect"
+
+    - name: "Test 2: Role without 'match' field (defaults to '#')"
+      ansible.builtin.assert:
+        that:
+          - "'#' in test2_result"
+          - test2_result['#']['browse'] == ['manager']
+          - test2_result['#']['manage'] == ['manager']
+        success_msg: "Test 2 passed: Missing 'match' defaults to '#'"
+        fail_msg: "Test 2 failed: Default match pattern incorrect"
+
+    - name: "Test 3: Role with match: None (defaults to '#')"
+      ansible.builtin.assert:
+        that:
+          - "'#' in test3_result"
+          - test3_result['#']['consume'] == ['consumer']
+        success_msg: "Test 3 passed: match=None defaults to '#'"
+        fail_msg: "Test 3 failed: None match not handled correctly"
+
+    - name: "Test 4: Role with match: '' (defaults to '#')"
+      ansible.builtin.assert:
+        that:
+          - "'#' in test4_result"
+          - test4_result['#']['send'] == ['producer']
+        success_msg: "Test 4 passed: match='' defaults to '#'"
+        fail_msg: "Test 4 failed: Empty match not handled correctly"
+
+    - name: "Test 5: Role with empty permissions"
+      ansible.builtin.assert:
+        that:
+          - test5_result is mapping
+          - "'test.#' not in test5_result"
+        success_msg: "Test 5 passed: Empty permissions skipped"
+        fail_msg: "Test 5 failed: Empty permissions not skipped"
+
+    - name: "Test 6: Multiple roles same match pattern"
+      ansible.builtin.assert:
+        that:
+          - "'topics.#' in test6_result"
+          - test6_result['topics.#']['send'] == ['admin', 'user']
+          - test6_result['topics.#']['consume'] == ['admin']
+        success_msg: "Test 6 passed: Multiple roles appended correctly"
+        fail_msg: "Test 6 failed: Role appending incorrect"
+
+    - name: "Test 7: Empty roles list"
+      ansible.builtin.assert:
+        that:
+          - test7_result == {}
+        success_msg: "Test 7 passed: Empty list returns {}"
+        fail_msg: "Test 7 failed: Empty list handling incorrect"
+
+    - name: "Test 8: Role missing 'name' field (should fail)"
+      ansible.builtin.assert:
+        that:
+          - test8_failed
+          - "'missing required' in test8_msg | lower"
+        success_msg: "Test 8 passed: Missing 'name' raises error"
+        fail_msg: "Test 8 failed: Missing 'name' should raise error"
+
+    - name: "Test 9: Role with name: None (should fail)"
+      ansible.builtin.assert:
+        that:
+          - test9_failed
+          - "'missing required' in test9_msg | lower"
+        success_msg: "Test 9 passed: name=None raises error"
+        fail_msg: "Test 9 failed: name=None should raise error"
+
+    - name: "Test 10: Role with name: '' (should fail)"
+      ansible.builtin.assert:
+        that:
+          - test10_failed
+          - "'missing required' in test10_msg | lower"
+        success_msg: "Test 10 passed: name='' raises error"
+        fail_msg: "Test 10 failed: name='' should raise error"
+
+    - name: "Test 11: Input is not a list (should fail)"
+      ansible.builtin.assert:
+        that:
+          - test11_failed
+          - "'requires a list' in test11_msg | lower"
+        success_msg: "Test 11 passed: Non-list input raises error"
+        fail_msg: "Test 11 failed: Non-list should raise error"
+
+    - name: "Test 12: Multiple roles same match, first with empty permissions"
+      ansible.builtin.assert:
+        that:
+          - "'orders.#' in test12_result"
+          - test12_result['orders.#']['consume'] == ['reader']
+          - test12_result['orders.#']['browse'] == ['reader']
+          - "'noperm' not in (test12_result['orders.#'].values() | list | flatten)"
+        success_msg: "Test 12 passed: First role with empty permissions skipped, second processed"
+        fail_msg: "Test 12 failed: Empty permissions not handled correctly with multiple roles"
+
+    - name: "All tests passed"
+      ansible.builtin.debug:
+        msg:
+          - Valid inputs processed correctly
+          - Default values applied correctly
+          - Edge cases handled properly
+          - Invalid inputs rejected with errors

--- a/plugins/filter/create_security_matches.py
+++ b/plugins/filter/create_security_matches.py
@@ -70,14 +70,15 @@ def create_security_matches(amq_broker_roles):
         match_pattern = role.get('match') or '#'
         permissions = role.get('permissions', [])
 
-        if match_pattern not in result:
-            result[match_pattern] = {}
+        if permissions:
+            if match_pattern not in result:
+                result[match_pattern] = {}
 
-        for permission in permissions:
-            if permission not in result[match_pattern]:
-                result[match_pattern][permission] = []
+            for permission in permissions:
+                if permission not in result[match_pattern]:
+                    result[match_pattern][permission] = []
 
-            result[match_pattern][permission].append(role_name)
+                result[match_pattern][permission].append(role_name)
 
     return result
 


### PR DESCRIPTION
Follow-up to #259
Github Issue: https://github.com/ansible-middleware/amq/issues/248
  Filter improvements:
  - Skip roles with empty permissions
  
  Test suite:
  - Test valid inputs (normal roles, defaults, edge cases)
  - Test invalid inputs (missing name, None, empty string)
  - Test output structure and role appending
  - 12 test cases covering all scenarios