### PR TITLE
Fix docs build by migrating to modern sphinx_antsibull_ext

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Clone the repository, checkout the tag you want to build, or pick the main branc
 
 Make sure your development machine has avilable:
 
-* python 3.11+
+* python 3.12+
 * virtualenv
 * docker (or podman)
 

--- a/docs/base_deployment.md
+++ b/docs/base_deployment.md
@@ -13,7 +13,7 @@ or cloud providers, or even bare-metal.
 
 On the machine running this guide, you'll need RHEL 9.2+, or in detail:
 
-* python 3.11+
+* python 3.12+
 * ansible-core >= 2.16
 * podman 5.1+
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,6 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx_antsibull_ext',
-    'ansible_basic_sphinx_ext',
 
 ]
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,4 @@ antsibull-changelog
 ansible-core>=2.16.0
 ansible-pygments
 sphinx-rtd-theme
-git+https://github.com/felixfontein/ansible-basic-sphinx-ext
 myst-parser

--- a/docs/static_cluster.md
+++ b/docs/static_cluster.md
@@ -15,7 +15,7 @@ or even bare-metal.
 
 On the machine running this guide, you'll need RHEL 9.2+, or in detail:
 
-* python 3.11+
+* python 3.12+
 * ansible-core >= 2.16
 * podman 5.1+
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -9,7 +9,7 @@ The test scenarios are available on the source code repository each on his own s
 
 ## Test playbooks
 
-Sample playbooks are provided in the `playbooks/` directory; to run the playbooks locally (requires a rhel system with python 3.9+, ansible, and systemd) the steps are as follows:
+Sample playbooks are provided in the `playbooks/` directory; to run the playbooks locally (requires a rhel system with python 3.12+, ansible, and systemd) the steps are as follows:
 
 ```
 # setup environment as above, then


### PR DESCRIPTION
The deprecated ansible_basic_sphinx_ext extension (archived Dec 2022) requires pkg_resources which was removed in setuptools >= 70.0.0.

The modern replacement sphinx_antsibull_ext is already included via antsibull-docs, so we can simply:
- Remove ansible_basic_sphinx_ext from extensions in conf.py
- Remove the deprecated extension from requirements.txt

This eliminates the pkg_resources dependency entirely.

Reference: https://github.com/felixfontein/ansible-basic-sphinx-ext states 'This extension is deprecated! Use sphinx_antsibull_ext instead'