### PR TITLE
Add support for ignore-scheme in jolokia-access.xml

### DIFF
--- a/molecule/console_access/converge.yml
+++ b/molecule/console_access/converge.yml
@@ -14,6 +14,7 @@
     activemq_network_check_enabled: true
     activemq_message_counter_enabled: true
     activemq_network_check_list: "127.0.0.1,8.8.8.8,{{ inventory_hostname }},{{ ansible_all_ipv4_addresses | join(',') }}"
+    activemq_cors_ignore_scheme: true
     activemq_hawtio_roles: [ 'admin', 'monitoring' ]
     activemq_users:
       - user: amq

--- a/molecule/console_access/verify.yml
+++ b/molecule/console_access/verify.yml
@@ -61,6 +61,18 @@
         quiet: true
         fail_msg: "Failed to retrieve configured users"
 
+    - name: Read jolokia-access.xml
+      ansible.builtin.slurp:
+        src: /opt/amq/amq-broker/etc/jolokia-access.xml
+      register: slurped_jolokia_access
+
+    - name: Check ignore-scheme is present in jolokia-access.xml
+      ansible.builtin.assert:
+        that:
+          - "'<ignore-scheme/>' in slurped_jolokia_access.content | b64decode"
+        quiet: true
+        fail_msg: "ignore-scheme element not found in jolokia-access.xml"
+
     - name: Check console redirect to login page
       ansible.builtin.uri:
         url: http://0.0.0.0:8161/console/

--- a/roles/activemq/README.md
+++ b/roles/activemq/README.md
@@ -469,6 +469,7 @@ activemq_broker_plugins:
 |`activemq_management_access_domains`| Fine grained management console accesses methods and roles per domain and key, `activemq_hawtio_roles` will be added to each domain access | `java.lang`, `org.apache.artemis.activemq` |
 |`activemq_cors_allow_origin`| List of CORS allow origin setting for jolokia | `[ *://0.0.0.0* ]` |
 |`activemq_cors_strict_checking`| Whether to enforce strict checking for CORS | `True` |
+|`activemq_cors_ignore_scheme`| Whether to ignore scheme (http/https) mismatch in CORS origin checks; enable when behind a TLS-terminating reverse proxy | `False` |
 
 Sample user/role configuration with one admin, a consumer and a producer:
 

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -211,6 +211,7 @@ activemq_hawtio_role: amq  ## DEPRECATED, use activemq_hawtio_roles
 activemq_hawtio_roles: "{{ activemq_hawtio_role.split(',') }}"
 activemq_cors_allow_origin: [ '*://0.0.0.0*' ]
 activemq_cors_strict_checking: true
+activemq_cors_ignore_scheme: false
 
 # NIO option
 activemq_nio_enabled: false

--- a/roles/activemq/meta/argument_specs.yml
+++ b/roles/activemq/meta/argument_specs.yml
@@ -369,6 +369,10 @@ argument_specs:
                 description: "Whether to enforce strict checking for CORS"
                 default: true
                 type: "bool"
+            activemq_cors_ignore_scheme:
+                description: "Whether to ignore scheme (http/https) mismatch in CORS origin checks; enable when behind a TLS-terminating reverse proxy"
+                default: false
+                type: "bool"
             activemq_management_access_default:
                 description: "fine grained management console accesses methods and roles, `activemq_hawtio_roles` roles will be added to each access"
                 default: "[ 'list*', 'get*', 'is*', 'set*', 'browse*', 'count*', '*' ]"

--- a/roles/activemq/templates/jolokia-access.xml.j2
+++ b/roles/activemq/templates/jolokia-access.xml.j2
@@ -28,5 +28,7 @@ under the License.
 {% endfor %}
 {% if activemq_cors_strict_checking %}        <strict-checking/>
 {% endif %}
+{% if activemq_cors_ignore_scheme %}        <ignore-scheme/>
+{% endif %}
     </cors>
 </restrict>


### PR DESCRIPTION
Add activemq_cors_ignore_scheme option to allow CORS scheme mismatch in Jolokia, needed when Artemis console is behind a TLS-terminating reverse proxy.

[AMW-598](https://redhat.atlassian.net/browse/AMW-598)