### PR TITLE
Replace deprecated _collections_compat import

### DIFF
--- a/plugins/filter/lists_mergeby.py
+++ b/plugins/filter/lists_mergeby.py
@@ -99,7 +99,7 @@ RETURN = '''
 '''
 
 from ansible.errors import AnsibleFilterError
-from ansible.module_utils.common._collections_compat import Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from ansible.utils.vars import merge_hash
 
 from collections import defaultdict

--- a/plugins/modules/activemq_facts.py
+++ b/plugins/modules/activemq_facts.py
@@ -110,7 +110,7 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import open_url, basic_auth_header
-from ansible.module_utils.six.moves.urllib.error import HTTPError
+from urllib.error import HTTPError
 from ansible.module_utils.common.text.converters import to_native
 
 


### PR DESCRIPTION
Replace ansible.module_utils.common._collections_compat with collections.abc, deprecated and scheduled for removal.

"[DEPRECATION WARNING]: The `ansible.module_utils.common._collections_compat` module is deprecated. This feature will be removed from ansible-core version 2.24. Use `collections.abc` from the Python standard library instead."

More info:
https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/common/_collections_compat.py

"Use collections.abc instead. This module exists only for backwards compatibility."

and replace ansible.module_utils.six.moves.urllib.parse with Python standard library equivalent

More info:
https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/six/__init__.py

""Use the Python standard library equivalent instead."

[AMW-577](https://redhat.atlassian.net/browse/AMW-577)